### PR TITLE
Reorganize Graphics section pages

### DIFF
--- a/docs/user-manual/graphics/advanced-rendering/index.md
+++ b/docs/user-manual/graphics/advanced-rendering/index.md
@@ -1,4 +1,4 @@
 ---
 title: Advanced Rendering
-sidebar_position: 7
+sidebar_position: 10
 ---

--- a/docs/user-manual/graphics/gaussian-splatting.md
+++ b/docs/user-manual/graphics/gaussian-splatting.md
@@ -1,6 +1,6 @@
 ---
 title: 3D Gaussian Splatting
-sidebar_position: 3.5
+sidebar_position: 7
 ---
 
 3D Gaussian Splatting is a relatively new technique for capturing and rendering photorealistic volumetric point clouds. Since the technique relies on photogrammetry, it is very quick, cheap and easy to generate high-quality rendered scenes.
@@ -29,7 +29,7 @@ Captured splats normally need to be edited to some degree. The generation proces
 
 ![SuperSplat](/img/user-manual/graphics/gaussian-splatting/supersplat.png)
 
-PlayCanvas provides a powerful 3D Gaussian Splat editor called [SuperSplat](https://playcanvas.com/supersplat/editor). SuperSplat is open-sourced under an MIT license on [GitHub](https://github.com/playcanvas/supersplat).
+PlayCanvas provides a powerful 3D Gaussian Splat editor called [SuperSplat](https://superspl.at/editor). SuperSplat is open-sourced under an MIT license on [GitHub](https://github.com/playcanvas/supersplat).
 
 ### Importing Splats
 
@@ -55,4 +55,3 @@ There are some limitations to keep in mind when working with splats:
 1. Fog has no effect.
 2. Dynamic lights have no effect.
 3. [Image Based Lighting](../physical-rendering/image-based-lighting) has no effect.
-4. Splats do not cast shadows.

--- a/docs/user-manual/graphics/layers/index.md
+++ b/docs/user-manual/graphics/layers/index.md
@@ -1,6 +1,6 @@
 ---
 title: Layers
-sidebar_position: 4
+sidebar_position: 9
 ---
 
 ## Layers Overview {#layers-overview}

--- a/docs/user-manual/graphics/particles.md
+++ b/docs/user-manual/graphics/particles.md
@@ -1,6 +1,6 @@
 ---
 title: Particles
-sidebar_position: 5
+sidebar_position: 7
 ---
 
 PlayCanvas provides comprehensive support for creating and editing particle systems.

--- a/docs/user-manual/graphics/shaders/index.md
+++ b/docs/user-manual/graphics/shaders/index.md
@@ -1,6 +1,6 @@
 ---
 title: Shaders
-sidebar_position: 6
+sidebar_position: 5
 ---
 
 When you import your 3D models into PlayCanvas, by default, they will use our [Physical Material][1]. This is a versatile material type that can cover a lot of your rendering needs.

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/advanced-rendering/index.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/advanced-rendering/index.md
@@ -1,4 +1,4 @@
 ---
 title: 高度なレンダリング
-sidebar_position: 7
+sidebar_position: 10
 ---

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/gaussian-splatting.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/gaussian-splatting.md
@@ -1,6 +1,6 @@
 ---
 title: 3D Gaussian Splatting
-sidebar_position: 3.5
+sidebar_position: 7
 ---
 
 3D Gaussian Splattingは、フォトリアリスティックなボリュメトリック点群をキャプチャしてレンダリングするための比較的新しい技術です。この技術はフォトグラメトリーに依存しているため、高品質なレンダリングシーンを非常に迅速、安価、かつ簡単に生成できます。
@@ -29,7 +29,7 @@ Inriaの[SIGGRAPH 2023の論文](https://repo-sam.inria.fr/fungraph/3d-gaussian-
 
 ![SuperSplat](/img/user-manual/graphics/gaussian-splatting/supersplat.png)
 
-PlayCanvasは、[SuperSplat](https://playcanvas.com/supersplat/editor)という強力な3D Gaussian Splatエディタを提供しています。SuperSplatは、[GitHub](https://github.com/playcanvas/supersplat)でMITライセンスの下でオープンソース化されています。
+PlayCanvasは、[SuperSplat](https://superspl.at/editor)という強力な3D Gaussian Splatエディタを提供しています。SuperSplatは、[GitHub](https://github.com/playcanvas/supersplat)でMITライセンスの下でオープンソース化されています。
 
 ### スプラットのインポート
 
@@ -55,4 +55,3 @@ PLYスプラットファイルをインポートするには：
 1. フォグは効果がありません。
 2. ダイナミックライトは効果がありません。
 3. [Image Based Lighting](../physical-rendering/image-based-lighting)は効果がありません。
-4. スプラットは影を落としません。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/layers/index.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/layers/index.md
@@ -1,6 +1,6 @@
 ---
 title: レイヤー
-sidebar_position: 4
+sidebar_position: 9
 ---
 
 ## レイヤーの概要 {#layers-overview}

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/particles.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/particles.md
@@ -1,6 +1,6 @@
 ---
 title: パーティクル
-sidebar_position: 5
+sidebar_position: 8
 ---
 
 PlayCanvasはパーティクルシステムの作成と編集のための包括的なサポートを提供します。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/shaders/index.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/shaders/index.md
@@ -1,6 +1,6 @@
 ---
 title: シェーダー
-sidebar_position: 6
+sidebar_position: 5
 ---
 
 3DモデルをPlayCanvasにインポートすると、デフォルトで当社の[Physical Material][1]が使用されます。これは、レンダリングの多くのニーズをカバーできる多用途なマテリアルタイプです。


### PR DESCRIPTION
Now looks like this, which I think is a marginally better flow:

![image](https://github.com/user-attachments/assets/8cc042bc-e7e8-4752-a4f0-fd5e65ead2fa)

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/developer.playcanvas.com/blob/main/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
