### PR TITLE
Add scriptName field to all ESM script examples

### DIFF
--- a/docs/user-manual/scripting/editor-users/hot-reloading.md
+++ b/docs/user-manual/scripting/editor-users/hot-reloading.md
@@ -44,6 +44,8 @@ For example:
 import { ScriptType, math } from 'playcanvas';
 
 export class Rotator extends Script {
+    static scriptName = 'rotator';
+
     /**
      * @attribute
      */

--- a/docs/user-manual/scripting/fundamentals/esm-scripts.md
+++ b/docs/user-manual/scripting/fundamentals/esm-scripts.md
@@ -25,6 +25,8 @@ ESM scripts must have the `.mjs` file extension:
 import { Script } from 'playcanvas';
 
 export class PlayerController extends Script {
+    static scriptName = 'playerController';
+
     initialize() {
         // Setup code here
     }
@@ -64,6 +66,8 @@ import { Script } from 'playcanvas';
 import { GAME_SETTINGS, clamp } from './config.mjs';
 
 export class PlayerController extends Script {
+    static scriptName = 'playerController';
+
     update(dt) {
         const speed = GAME_SETTINGS.playerSpeed;
         // Use clamp function...

--- a/docs/user-manual/scripting/fundamentals/events.md
+++ b/docs/user-manual/scripting/fundamentals/events.md
@@ -27,6 +27,8 @@ import TabItem from '@theme/TabItem';
 import { Script } from 'playcanvas';
 
 export class Player extends Script {
+    static scriptName = 'player';
+
     update(dt) {
         const x = 1;
         const y = 1;
@@ -60,6 +62,8 @@ Listen for events firing by using `on()` and `off()`. In this example, the displ
 import { Script } from 'playcanvas';
 
 export class Display extends Script {
+    static scriptName = 'display';
+
     /**
      * @attribute
      * @type {Entity}
@@ -130,6 +134,8 @@ Firing the `player:move` event:
 import { Script } from 'playcanvas';
 
 export class Player extends Script {
+    static scriptName = 'player';
+
     update(dt) {
         var x = 1;
         var y = 1;
@@ -138,6 +144,8 @@ export class Player extends Script {
 }
 
 export class Display extends Script {
+    static scriptName = 'display';
+
     initialize() {
         // Method to call when player moves
         const onPlayerMove = (x, y) => {

--- a/docs/user-manual/scripting/fundamentals/getting-started.md
+++ b/docs/user-manual/scripting/fundamentals/getting-started.md
@@ -27,6 +27,8 @@ import TabItem from '@theme/TabItem';
 import { Script } from 'playcanvas';
 
 export class MyScript extends Script {
+    static scriptName = 'myScript';
+
     /** @attribute */
     speed = 10;
 
@@ -102,6 +104,8 @@ Attributes let you expose script properties to the editor, making scripts config
 import { Color, Script } from 'playcanvas';
 
 export class Configurable extends Script {
+    static scriptName = 'configurable';
+
     /** @attribute */
     speed = 5;
     

--- a/docs/user-manual/scripting/fundamentals/script-attributes/esm.md
+++ b/docs/user-manual/scripting/fundamentals/script-attributes/esm.md
@@ -23,6 +23,8 @@ Let's start with a simple rotate script example.
 import { Script } from 'playcanvas';
 
 export class Rotator extends Script {
+    static scriptName = 'rotator';
+
     /**
      * You can now set the `speed`property dynamically in the editor.
      *
@@ -236,6 +238,8 @@ const Lights = {
 }
 
 class MyScript extends Script {
+    static scriptName = 'myScript';
+
     /**
      * @attribute
      * @type {Lights}
@@ -256,6 +260,8 @@ Let’s walk through an example:
 
 ```javascript
 export class Delorean extends Script {
+    static scriptName = 'delorean';
+
     /**
      * @attribute
      */
@@ -274,6 +280,8 @@ We can achieve this by using the `@enabledif` tag:
 
 ```javascript
 export class Delorean extends Script {
+    static scriptName = 'delorean';
+
     /**
      * @attribute
      */
@@ -295,6 +303,8 @@ You can also use more expressive conditions. If the condition evaluates to a [tr
 
 ```javascript
 export class Delorean extends Script {
+    static scriptName = 'delorean';
+
     /**
      * @attribute
      */
@@ -336,6 +346,8 @@ Attribute groups are essentially objects that contain sub-attributes:
 
 ```javascript
 class GameLogic extends Script {
+    static scriptName = 'gameLogic';
+
     /** 
      * @attribute 
      * `power` and `speed` are exposed as sub attributes
@@ -363,6 +375,8 @@ A simple inline way of declaring attribute groups
 
 ```javascript
 class GameLogic extends Script {
+    static scriptName = 'gameLogic';
+
     /** @attribute */
     enemy = { power: 10, speed: 3 }
 }
@@ -380,6 +394,8 @@ This is a more modular way of declaring Attribute Groups. Whilst it is more verb
  */
 
 class GameLogic extends Script {
+    static scriptName = 'gameLogic';
+
     /** 
      * @attribute 
      * @type {Enemy}
@@ -403,6 +419,8 @@ class Enemy {
 }
 
 class GameLogic extends Script {
+    static scriptName = 'gameLogic';
+
     /**
      * @attribute 
      * @type {Enemy}
@@ -432,6 +450,8 @@ Interface attributes can be used as arrays, just like plain attributes. This mea
 
 ```javascript
 class GameLogic extends Script {
+    static scriptName = 'gameLogic';
+
     /**
      * @attribute
      * @type {Enemy[]}

--- a/docs/user-manual/scripting/index.md
+++ b/docs/user-manual/scripting/index.md
@@ -28,6 +28,8 @@ import TabItem from '@theme/TabItem';
 import { Script } from 'playcanvas';
 
 export class Rotate extends Script {
+    static scriptName = 'rotate';
+
     /** @attribute */
     speed = 10;
 

--- a/docs/user-manual/scripting/migration-guide.md
+++ b/docs/user-manual/scripting/migration-guide.md
@@ -115,6 +115,8 @@ const watch = (target, prop) => {
 import { Script } from 'playcanvas'
 
 export class Rotate extends Script {
+    static scriptName = 'rotate';
+
     /** attribute */
     speed = 10;
 
@@ -150,6 +152,7 @@ Instead, if you do need to copy values, we recommend you do it manually and expl
 import { Script, Vec3 } from 'playcanvas';
 
 export class Rotate extends Script {
+    static scriptName = 'rotate';
 
     _speed = new Vec3();
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scripting/editor-users/hot-reloading.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scripting/editor-users/hot-reloading.md
@@ -44,6 +44,8 @@ MyScript.prototype.swap = function(old) {
 import { ScriptType, math } from 'playcanvas';
 
 export class Rotator extends Script {
+    static scriptName = 'rotator';
+
     /**
      * @attribute
      */

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scripting/fundamentals/esm-scripts.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scripting/fundamentals/esm-scripts.md
@@ -25,6 +25,8 @@ ESMスクリプトは、`.mjs`拡張子である必要があります：
 import { Script } from 'playcanvas';
 
 export class PlayerController extends Script {
+    static scriptName = 'playerController';
+
     initialize() {
         // 初期化コードをここに
     }
@@ -64,6 +66,8 @@ import { Script } from 'playcanvas';
 import { GAME_SETTINGS, clamp } from './config.mjs';
 
 export class PlayerController extends Script {
+    static scriptName = 'playerController';
+
     update(dt) {
         const speed = GAME_SETTINGS.playerSpeed;
         // clamp関数を使う...

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scripting/fundamentals/events.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scripting/fundamentals/events.md
@@ -27,6 +27,8 @@ import TabItem from '@theme/TabItem';
 import { Script } from 'playcanvas';
 
 export class Player extends Script {
+    static scriptName = 'player';
+
     update(dt) {
         const x = 1;
         const y = 1;
@@ -60,6 +62,8 @@ Player.prototype.update = function (dt) {
 import { Script } from 'playcanvas';
 
 export class Display extends Script {
+    static scriptName = 'display';
+
     /**
      * @attribute
      * @type {Entity}
@@ -130,6 +134,8 @@ Display.prototype.initialize = function () {
 import { Script } from 'playcanvas';
 
 export class Player extends Script {
+    static scriptName = 'player';
+
     update(dt) {
         var x = 1;
         var y = 1;
@@ -138,6 +144,8 @@ export class Player extends Script {
 }
 
 export class Display extends Script {
+    static scriptName = 'display';
+
     initialize() {
         // Method to call when player moves
         const onPlayerMove = (x, y) => {

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scripting/fundamentals/getting-started.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scripting/fundamentals/getting-started.md
@@ -27,6 +27,8 @@ import TabItem from '@theme/TabItem';
 import { Script } from 'playcanvas';
 
 export class MyScript extends Script {
+    static scriptName = 'myScript';
+
     /** @attribute */
     speed = 10;
 
@@ -102,6 +104,8 @@ MyScript.prototype.update = function(dt) {
 import { Color, Script } from 'playcanvas';
 
 export class Configurable extends Script {
+    static scriptName = 'configurable';
+
     /** @attribute */
     speed = 5;
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scripting/fundamentals/script-attributes/esm.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scripting/fundamentals/script-attributes/esm.md
@@ -23,6 +23,8 @@ sidebar_position: 1
 import { Script } from 'playcanvas';
 
 export class Rotator extends Script {
+    static scriptName = 'rotator';
+
     /**
      * エディターで`speed`プロパティを動的に設定できるようになりました。
      *
@@ -235,6 +237,8 @@ const Lights = {
 }
 
 class MyScript extends Script {
+    static scriptName = 'myScript';
+
     /**
      * @attribute
      * @type {Lights}
@@ -255,6 +259,8 @@ class MyScript extends Script {
 
 ```javascript
 export class Delorean extends Script {
+    static scriptName = 'delorean';
+
     /**
      * @attribute
      */
@@ -273,6 +279,8 @@ export class Delorean extends Script {
 
 ```javascript
 export class Delorean extends Script {
+    static scriptName = 'delorean';
+
     /**
      * @attribute
      */
@@ -294,6 +302,8 @@ export class Delorean extends Script {
 
 ```javascript
 export class Delorean extends Script {
+    static scriptName = 'delorean';
+
     /**
      * @attribute
      */
@@ -335,6 +345,8 @@ export class Delorean extends Script {
 
 ```javascript
 class GameLogic extends Script {
+    static scriptName = 'gameLogic';
+
     /** 
      * @attribute 
      * `power` と `speed` はサブ属性として公開されます
@@ -362,6 +374,8 @@ class GameLogic extends Script {
 
 ```javascript
 class GameLogic extends Script {
+    static scriptName = 'gameLogic';
+
     /** @attribute */
     enemy = { power: 10, speed: 3 }
 }
@@ -382,6 +396,8 @@ class GameLogic extends Script {
  */
 
 class GameLogic extends Script {
+    static scriptName = 'gameLogic';
+
     /**
      * @attribute
      * @type {Enemy}
@@ -405,6 +421,8 @@ class Enemy {
 }
 
 class GameLogic extends Script {
+    static scriptName = 'gameLogic';
+
     /**
      * @attribute
      * @type {Enemy}
@@ -434,6 +452,8 @@ class GameLogic extends Script {
 
 ```javascript
 class GameLogic extends Script {
+    static scriptName = 'gameLogic';
+
     /**
      * @attribute
      * @type {Enemy[]}

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scripting/index.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scripting/index.md
@@ -28,6 +28,8 @@ import TabItem from '@theme/TabItem';
 import { Script } from 'playcanvas';
 
 export class Rotate extends Script {
+    static scriptName = 'rotate';
+
     /** @attribute */
     speed = 10;
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scripting/migration-guide.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/scripting/migration-guide.md
@@ -115,6 +115,8 @@ const watch = (target, prop) => {
 import { Script } from 'playcanvas'
 
 export class Rotate extends Script {
+    static scriptName = 'rotate';
+
     /** attribute */
     speed = 10;
 
@@ -149,6 +151,7 @@ export class Rotate extends Script {
 import { Script, Vec3 } from 'playcanvas';
 
 export class Rotate extends Script {
+    static scriptName = 'rotate';
 
     _speed = new Vec3();
 


### PR DESCRIPTION


I confirm I have read the [contributing guidelines](https://github.com/playcanvas/developer.playcanvas.com/blob/main/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
