### PR TITLE
Rename Engine Web Components

### DIFF
--- a/docs/user-manual/web-components/index.md
+++ b/docs/user-manual/web-components/index.md
@@ -1,9 +1,9 @@
 ---
-title: Engine Web Components
+title: PlayCanvas Web Components
 sidebar_position: 5.5
 ---
 
-The PlayCanvas Engine Web Components are a powerful set of custom HTML elements that make it incredibly easy to embed interactive 3D content directly into your web pages. Built on modern web standards, these components bridge the gap between traditional web development and 3D graphics, allowing you to create immersive experiences with simple HTML markup.
+PlayCanvas Web Components are a powerful set of custom HTML elements that make it incredibly easy to embed interactive 3D content directly into your web pages. Built on modern web standards, these components bridge the gap between traditional web development and 3D graphics, allowing you to create immersive experiences with simple HTML markup.
 
 ## What Are Web Components?
 

--- a/docs/user-manual/web-components/tags/index.md
+++ b/docs/user-manual/web-components/tags/index.md
@@ -3,7 +3,7 @@ title: Tag Reference
 sidebar_position: 5
 ---
 
-Here is a complete list of the tags that are available in the PlayCanvas Engine Web Components.
+Here is a complete list of the tags that are available in PlayCanvas Web Components.
 
 | Tag | Description |
 | --- | --- |

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/index.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/index.md
@@ -1,9 +1,9 @@
 ---
-title: Engine Web Components
+title: PlayCanvas Web Components
 sidebar_position: 5.5
 ---
 
-PlayCanvas Engine Web Components は、インタラクティブな3Dコンテンツをウェブページに直接埋め込むことを非常に簡単にする、強力なカスタムHTML要素のセットです。最新のウェブ標準に基づいて構築されており、これらのコンポーネントは従来のウェブ開発と3Dグラフィックスの間のギャップを埋め、シンプルなHTMLマークアップで没入型のエクスペリエンスを作成することを可能にします。
+PlayCanvas Web Components は、インタラクティブな3Dコンテンツをウェブページに直接埋め込むことを非常に簡単にする、強力なカスタムHTML要素のセットです。最新のウェブ標準に基づいて構築されており、これらのコンポーネントは従来のウェブ開発と3Dグラフィックスの間のギャップを埋め、シンプルなHTMLマークアップで没入型のエクスペリエンスを作成することを可能にします。
 
 ## Web Componentsとは？
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/index.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/index.md
@@ -3,7 +3,7 @@ title: タグリファレンス
 sidebar_position: 5
 ---
 
-以下は、PlayCanvas Engine Web Components で利用可能なタグの完全なリストです。
+以下は、PlayCanvas Web Components で利用可能なタグの完全なリストです。
 
 | タグ | 説明 |
 | --- | --- |

--- a/sidebars.js
+++ b/sidebars.js
@@ -88,7 +88,7 @@ const sidebars = {
     },
     {
       type: 'category',
-      label: 'Engine Web Components',
+      label: 'PlayCanvas Web Components',
       link: {
         type: 'doc',
         id: 'user-manual/web-components/index',

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -15,6 +15,7 @@
   --ifm-color-primary-lightest: #ffd4b7;
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
+  --doc-sidebar-width: 305px;
 
   /* shadows */
   --ring-offset-shadow: 0 0 #0000;


### PR DESCRIPTION
Call them "PlayCanas Web Components" instead. Expand width of sidebar by 5px to accommodate the longer name without wrapping.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/developer.playcanvas.com/blob/main/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
