### PR TITLE
Correct typo in Interface Attributes section

### DIFF
--- a/docs/user-manual/scripting/fundamentals/script-attributes/esm.md
+++ b/docs/user-manual/scripting/fundamentals/script-attributes/esm.md
@@ -434,7 +434,7 @@ class GameLogic extends Script {
 
 ### Interface Attributes
 
-If you want to group attributes together and set individual constraints on its members you can use an Interface Attribute. This provides a morea more flexible way of grouping attributes.
+If you want to group attributes together and set individual constraints on its members you can use an Interface Attribute. This provides a more flexible way of grouping attributes.
 
 ```javascript
 /** @interface */


### PR DESCRIPTION
Fix typo in the explanation of Interface Attributes. 

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/developer.playcanvas.com/blob/main/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
