### PR TITLE
Add API documentation for PlayCanvas React

### DIFF
--- a/docs/user-manual/playcanvas-react/api/align.mdx
+++ b/docs/user-manual/playcanvas-react/api/align.mdx
@@ -1,0 +1,36 @@
+---
+title: Align
+description: Documentation for the Align component
+---
+
+The `Align` component is a simple container that positions an entity relative to its parent. This can be useful when using 3D assets that are offset from the origin. Sometimes, you just want to sit the asset on the ground, or align it with the camera.
+
+The `Align` component accepts the following props: `top`, `bottom`, `left`, `right`, `front`, `back`.
+
+## Usage
+
+This example will align the asset to the bottom right of the parent entity.
+
+```jsx copy
+import { Entity } from '@playcanvas/react'
+import { Align, Render } from '@playcanvas/react/components'
+
+export default function Scene() {
+  return (
+    <Entity>
+      <Align bottom right>
+        <Render type="box" />
+      </Align>
+    </Entity>
+  )
+}
+```
+
+## Properties
+
+```tsx asTypedoc
+import { Align } from '@playcanvas/react/components'
+type $ = React.ComponentProps<typeof Align>;
+export default $;
+```
+

--- a/docs/user-manual/playcanvas-react/api/anim.mdx
+++ b/docs/user-manual/playcanvas-react/api/anim.mdx
@@ -1,0 +1,38 @@
+---
+title: Anim
+description: Documentation for the Anim component
+---
+
+The `Anim` component enables animation playback for an [Entity](./entity). It allows you to play animation clips from animation assets and control their playback.
+
+## Usage
+
+```jsx copy
+import { Entity } from '@playcanvas/react'
+import { Anim, Render } from '@playcanvas/react/components'
+import { useModel } from '@playcanvas/react/hooks'
+
+const AnimatingDinosaur = (props) => {
+  const { asset } = useModel('/dinosaur.glb')
+
+  if (!asset) return null
+
+  return (
+    <Entity {...props}>
+      <Render type="asset" asset={asset} />
+      <Anim asset={asset} clip="Walk" loop />
+    </Entity>
+  )
+}
+```
+
+Learn more about the [Anim Component](https://api.playcanvas.com/engine/classes/AnimComponent.html) in the PlayCanvas documentation.
+
+## Properties
+
+```tsx asTypedoc
+import { Anim } from '@playcanvas/react/components'
+type $ = React.ComponentProps<typeof Anim>;
+export default $;
+```
+

--- a/docs/user-manual/playcanvas-react/api/application.mdx
+++ b/docs/user-manual/playcanvas-react/api/application.mdx
@@ -1,0 +1,31 @@
+---
+title: Application
+description: The `Application` component is the root component for any PlayCanvas React application. It initializes and manages the canvas and PlayCanvas application instance.
+---
+
+The `<Application />` is the root your PlayCanvas React application. It initializes the engine and provides a rendering context. An Application maps to a single canvas in your app.
+
+You can set the fill mode and resolution mode to control how the canvas fills the window, and other properties that control the graphics device.
+
+```jsx copy
+import { Application } from '@playcanvas/react'
+
+export default function Scene() {
+  return (
+    <Application 
+      fillMode={FILLMODE_FILL_WINDOW}
+      resolutionMode={RESOLUTION_AUTO}
+    >
+      {/* Your scene content */}
+    </Application>
+  )
+}
+```
+
+## Properties
+
+```tsx asTypedoc
+import { Application } from '@playcanvas/react'
+type $ = React.ComponentProps<typeof Application>;
+export default $;
+```

--- a/docs/user-manual/playcanvas-react/api/camera.mdx
+++ b/docs/user-manual/playcanvas-react/api/camera.mdx
@@ -1,0 +1,48 @@
+---
+title: Camera
+description: Documentation for the Camera component
+---
+
+import { CodeExample, Staging } from '@site/src/components/playcanvas-react/CodeExample';
+import PlayCanvasReactExample from '@site/src/components/playcanvas-react/PlayCanvasReactExample';
+import { Entity } from '@playcanvas/react';
+import { Camera } from '@playcanvas/react/components';
+
+The `Camera` component enables an [Entity](./entity) to render a scene. You can use the entity's position and rotation to control the camera.
+
+## Usage
+
+A `Camera` is a component, so you attach it to an `Entity` and the camera will render the scene from the entity's position and rotation.
+
+<CodeExample 
+  label="Camera Example" 
+  filename="camera.jsx" 
+  code={`import { Application, Entity } from '@playcanvas/react'
+import { Camera } from '@playcanvas/react/components'
+
+export default function Scene() {
+  return (
+    <Application>
+      <Entity position={[0, 0, 5]}>
+        <Camera fov={28} clearColor="#1a1a1a" />
+      </Entity>
+    </Application>
+  )
+}`}>
+  <PlayCanvasReactExample>
+    <Entity position={[0, 0, 5]}>
+      <Camera fov={28} clearColor="#1a1a1a" />
+    </Entity>
+  </PlayCanvasReactExample>
+</CodeExample>
+
+Learn more about the [Camera Component](https://api.playcanvas.com/engine/classes/CameraComponent.html) in the PlayCanvas documentation.
+
+## Properties
+
+```tsx asTypedoc
+import { Camera } from '@playcanvas/react/components'
+type $ = React.ComponentProps<typeof Camera>;
+export default $;
+```
+

--- a/docs/user-manual/playcanvas-react/api/collision.mdx
+++ b/docs/user-manual/playcanvas-react/api/collision.mdx
@@ -1,0 +1,44 @@
+---
+title: Collision
+description: Documentation for the Collision component
+---
+
+The `Collision` component attaches a PlayCanvas [Collision Component](https://api.playcanvas.com/engine/classes/CollisionComponent.html) to an [Entity](./entity).
+
+It allows an Entity to participate in collision detection with other entities that have collision components. This is useful for physics simulations, trigger zones, and other gameplay mechanics that require detecting when objects intersect.
+
+:::note
+Enable physics by installing `ammo.js` and enabling physics on the Application using `<Application usePhysics/>`.
+:::
+
+## Usage
+
+You attach a Collision component to an Entity in the same way you would attach a Render component. To work with physics, you should also attach a `Rigidbody` component to the same `Entity`, and probably a `Render` component too.
+
+```jsx copy
+import { Application, Entity } from '@playcanvas/react'
+import { Collision, Rigidbody, Render } from '@playcanvas/react/components'
+
+export default function Scene() {
+  return (
+    <Application usePhysics>
+      <Entity>
+        <Collision type="box" />
+        <Rigidbody type="dynamic" mass={12} />
+        <Render type="box" />
+      </Entity>
+    </Application>
+  )
+}
+```
+
+Learn more about [Collision Components](https://api.playcanvas.com/engine/classes/CollisionComponent.html) in the PlayCanvas documentation. Also see the [Rigidbody](./rigidbody) component for more information on how to use collision components with physics.
+
+## Properties
+
+```tsx asTypedoc
+import { Collision } from '@playcanvas/react/components'
+type $ = React.ComponentProps<typeof Collision>;
+export default $;
+```
+

--- a/docs/user-manual/playcanvas-react/api/entity.mdx
+++ b/docs/user-manual/playcanvas-react/api/entity.mdx
@@ -1,0 +1,32 @@
+---
+title: Entity
+description: The `Entity` component is the fundamental building block in PlayCanvas React applications. It represents a node in the scene graph hierarchy and can contain other entities as children, as well as components that define its behavior and appearance.
+---
+
+The `Entity` component is the fundamental building block in PlayCanvas React applications. It represents a node in the scene graph hierarchy and can contain other entities as children, as well as components that define its behavior and appearance.
+
+```jsx copy
+import { Entity } from '@playcanvas/react'
+
+export default function Scene() {
+  return (
+    <Entity>
+      <Entity name="child" />
+      <Entity name="other-child">
+        <Entity name="nested-child" />
+      </Entity>
+    </Entity>
+  )
+}
+```
+
+Entities on their own are not visible, they need components to have behavior. You can add components to an entity by nesting them within the `Entity` component.
+
+## Properties
+
+```tsx asTypedoc
+import { Entity } from '@playcanvas/react'
+type $ = React.ComponentProps<typeof Entity>;
+export default $;
+```
+

--- a/docs/user-manual/playcanvas-react/api/environment.mdx
+++ b/docs/user-manual/playcanvas-react/api/environment.mdx
@@ -1,0 +1,54 @@
+---
+title: Environment
+description: Documentation for the Environment component
+---
+
+The `Environment` component is used to configure the environment lighting and skybox for a scene. It provides a comprehensive way to set up atmospheric lighting, skyboxes, and environmental effects that affect the entire scene.
+
+## Overview
+
+The Environment component combines several PlayCanvas scene and sky properties into a single, easy-to-use component:
+
+- **Skybox**: Sets the background texture for the scene
+- **Environment Atlas**: Provides Image-Based Lighting (IBL) for realistic environmental reflections
+- **Sky Settings**: Controls sky dome properties, rotation, scale, and positioning
+- **Scene Settings**: Manages exposure, luminance, and other global lighting parameters
+
+## Usage
+
+The Environment component should be placed within an `<Application>` component. Only one Environment component should be used per application instance.
+
+```jsx copy
+import { Environment } from '@playcanvas/react/components'
+import { useEnvAtlas } from '@playcanvas/react/hooks'
+
+const EnvironmentExample = () => {
+  const { asset: envAtlas } = useEnvAtlas('/env_atlas.png')
+
+  return (
+    <Application>
+      <Environment 
+        envAtlas={envAtlas}
+        exposure={1.2}
+        showSkybox={false}
+      />
+      {/* Your scene entities here */}
+    </Application>
+  )
+}
+```
+
+## Important Notes
+
+- **Single Instance**: Only one `<Environment/>` component should be used per application instance
+- **Asset Requirements**: The `skybox` and `envAtlas` props expect PlayCanvas Asset instances, typically loaded using hooks
+- **Automatic Cleanup**: The component automatically restores default values when unmounted
+
+## Properties
+
+```tsx asTypedoc
+import { Environment } from '@playcanvas/react/components'
+type $ = React.ComponentProps<typeof Environment>;
+export default $;
+```
+

--- a/docs/user-manual/playcanvas-react/api/gsplat.mdx
+++ b/docs/user-manual/playcanvas-react/api/gsplat.mdx
@@ -1,0 +1,41 @@
+---
+title: GSplat
+description: Documentation for the GSplat component
+---
+
+**Gaussian Splats** are a new way of capturing and rendering high quality 3D content. They capture the shape and lighting of a scene in a way that produces incredibly high quality results.
+
+Learn more about [Gaussian Splatting](/user-manual/gaussian-splatting/) in the PlayCanvas documentation.
+
+## Usage
+
+Once you load a Gaussian Splat model, you can use the `GSplat` component to render it.
+
+```jsx copy
+import { Entity } from '@playcanvas/react'
+import { GSplat } from '@playcanvas/react/components'
+import { useSplat } from '@playcanvas/react/hooks'
+
+const SplatModel = ({ src, ...props }) => {
+  const { asset } = useSplat(src)
+
+  if (!asset) return null
+
+  return (
+    <Entity {...props}>
+      <GSplat asset={asset} />
+    </Entity>
+  )
+}
+```
+
+Learn more about the [GSplat Component](https://api.playcanvas.com/engine/classes/GSplatComponent.html) in the PlayCanvas documentation.
+
+## Properties
+
+```tsx asTypedoc
+import { GSplat } from '@playcanvas/react/components'
+type $ = React.ComponentProps<typeof GSplat>;
+export default $;
+```
+

--- a/docs/user-manual/playcanvas-react/api/light.mdx
+++ b/docs/user-manual/playcanvas-react/api/light.mdx
@@ -1,0 +1,52 @@
+---
+title: Light
+description: Documentation for the Light component
+---
+
+import { CodeExample } from '@site/src/components/playcanvas-react/CodeExample';
+import PlayCanvasReactExample from '@site/src/components/playcanvas-react/PlayCanvasReactExample';
+import { Entity } from '@playcanvas/react';
+import { Light, Render } from '@playcanvas/react/components';
+
+The `Light` component allows an Entity to emit light. When attached to an `Entity`, the light can be positioned and oriented using the entity's transform. Lights can be directional, point, or spot.
+
+## Usage
+
+<CodeExample 
+  label="Directional Light Example" 
+  filename="directional-light.jsx" 
+  code={`import { Application, Entity } from '@playcanvas/react'
+import { Light, Render } from '@playcanvas/react/components'
+
+export default function Scene() {
+  return (
+    <Application>
+      <Entity>
+        <Light type="directional" intensity={0.8} />
+      </Entity>
+      <Entity position={[0, 0, 0]}>
+        <Render type="box" />
+      </Entity>
+    </Application>
+  )
+}`}>
+  <PlayCanvasReactExample>
+    <Entity>
+      <Light type="directional" intensity={0.8} />
+    </Entity>
+    <Entity position={[0, 0, 0]}>
+      <Render type="box" />
+    </Entity>
+  </PlayCanvasReactExample>
+</CodeExample>
+
+Learn more about [Lights](https://api.playcanvas.com/engine/classes/LightComponent.html) in the PlayCanvas documentation.
+
+## Properties
+
+```tsx asTypedoc
+import { Light } from '@playcanvas/react/components'
+type $ = React.ComponentProps<typeof Light>;
+export default $;
+```
+

--- a/docs/user-manual/playcanvas-react/api/render.mdx
+++ b/docs/user-manual/playcanvas-react/api/render.mdx
@@ -1,0 +1,67 @@
+---
+title: Render
+description: Documentation for the Render component
+---
+
+import { CodeExample } from '@site/src/components/playcanvas-react/CodeExample';
+import PlayCanvasReactExample from '@site/src/components/playcanvas-react/PlayCanvasReactExample';
+import { Entity } from '@playcanvas/react';
+import { Render } from '@playcanvas/react/components';
+
+The `Render` component allows an `Entity` to display a 3D asset or primitive shape. You can use the `type` prop to render a primitive shape or pass an asset to the `asset` prop to render a 3D model.
+
+## Usage
+
+### Rendering a Primitive
+
+<CodeExample 
+  label="Render Box Primitive" 
+  filename="render-box.jsx" 
+  code={`import { Application, Entity } from '@playcanvas/react'
+import { Render } from '@playcanvas/react/components'
+
+export default function Scene() {
+  return (
+    <Application>
+      <Entity position={[0, 0, 0]}>
+        <Render type="box" />
+      </Entity>
+    </Application>
+  )
+}`}>
+  <PlayCanvasReactExample>
+    <Entity position={[0, 0, 0]}>
+      <Render type="box" />
+    </Entity>
+  </PlayCanvasReactExample>
+</CodeExample>
+
+### Rendering an Asset
+
+To render a 3D model loaded from a URL, you can use the asset type and pass the asset directly to the `asset` prop.
+
+```jsx copy
+import { Render } from '@playcanvas/react/components'
+import { useModel } from '@playcanvas/react/hooks'
+
+const RenderModel = () => {
+  const { asset } = useModel('model.glb')
+
+  if (!asset) return null
+
+  return <Entity>
+    <Render type="asset" asset={asset} />
+  </Entity>
+}
+```
+
+Learn more about the [Render Component](https://api.playcanvas.com/engine/classes/RenderComponent.html) in the PlayCanvas documentation.
+
+## Properties
+
+```tsx asTypedoc
+import { Render } from '@playcanvas/react/components'
+type $ = React.ComponentProps<typeof Render>;
+export default $;
+```
+

--- a/docs/user-manual/playcanvas-react/api/rigidbody.mdx
+++ b/docs/user-manual/playcanvas-react/api/rigidbody.mdx
@@ -1,0 +1,42 @@
+---
+title: Rigidbody
+description: Documentation for the Rigidbody component
+---
+
+The `Rigidbody` component enables physics for an [Entity](./entity), allowing it to interact with the global physics simulation. You can apply forces, torques, and other physics behaviors to an entity with a `Rigidbody` component and it will respond accordingly.
+
+:::note
+Run `npm i ammo.js` and use `<Application usePhysics/>` to enable physics.
+:::
+
+You can learn more about how physics work in PlayCanvas in the [Physics docs](/user-manual/physics/).
+
+## Usage
+
+```jsx copy
+import { Application, Entity } from '@playcanvas/react'
+import { Rigidbody, Collision, Render } from '@playcanvas/react/components'
+
+export default function Scene() {
+  return (
+    <Application usePhysics>
+      <Entity position={[0, 5, 0]}>
+        <Rigidbody type="dynamic" mass={12} />
+        <Collision type="box" />
+        <Render type="box" />
+      </Entity>
+    </Application>
+  )
+}
+```
+
+Learn more about the [RigidBody Component](https://api.playcanvas.com/engine/classes/RigidBodyComponent.html) in the PlayCanvas documentation.
+
+## Properties
+
+```tsx asTypedoc
+import { Rigidbody } from '@playcanvas/react/components'
+type $ = React.ComponentProps<typeof Rigidbody>;
+export default $;
+```
+

--- a/docs/user-manual/playcanvas-react/api/script.mdx
+++ b/docs/user-manual/playcanvas-react/api/script.mdx
@@ -1,0 +1,49 @@
+---
+title: Script
+description: Documentation for the Script component
+---
+
+The `Script` component provides a simple imperative way to add behaviors to an `Entity`.
+
+This is useful for things like physics, animation, and interactivity where, for performance reasons, you want to bypass updating React props. It allows you to hook into the engine's update loop outside of React, which is useful for performance-critical code. You can also leverage existing Scripts from PlayCanvas Editor Projects.
+
+There's more information about [Scripts in the docs](/user-manual/scripting/).
+
+## Usage
+
+The `Script` component takes a class that extends the PlayCanvas [Script](https://api.playcanvas.com/engine/classes/Script.html) class and attaches it to the `Entity`. Any additional props are passed to the Script class directly and can be used as properties on the class.
+
+In the example below, we create a simple script that rotates the entity every frame. The `update()` method is called every frame and the speed prop is used as a class property. `this.entity` refers to the parent `Entity` the Script is attached to.
+
+```jsx
+import { Entity } from '@playcanvas/react'
+import { Script, Render } from '@playcanvas/react/components'
+import { Script as PcScript } from 'playcanvas'
+
+// This class runs in the scope of the entity it's attached to
+class SpinMe extends PcScript {
+  update(dt) {
+    this.entity.rotate(0, dt * this.speed, 0)
+  }
+}
+
+const SpinningCube = () => {
+  return (
+    <Entity>
+      <Render type="box" />
+      <Script script={SpinMe} speed={10} />
+    </Entity>
+  )
+}
+```
+
+Learn more about the [Script Component](https://api.playcanvas.com/engine/classes/ScriptComponent.html) in the PlayCanvas documentation.
+
+## Properties
+
+```tsx asTypedoc
+import { Script } from '@playcanvas/react/components'
+type $ = React.ComponentProps<typeof Script>;
+export default $;
+```
+

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -5,6 +5,7 @@
 // See: https://docusaurus.io/docs/api/docusaurus-config
 
 import {themes as prismThemes} from 'prism-react-renderer';
+import remarkTypedoc from './utils/plugins/remark-typedoc.mjs';
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
@@ -36,6 +37,7 @@ const config = {
   markdown: {
     mermaid: true,
   },
+
   themes: ['@docusaurus/theme-mermaid', '@docusaurus/theme-live-codeblock'],
 
   plugins: [
@@ -131,6 +133,35 @@ const config = {
         docs: {
           routeBasePath: '/', // Serve the docs at the site's root
           sidebarPath: './sidebars.js',
+          remarkPlugins: [
+            [remarkTypedoc, {
+               typeResolver: ({ displayName, types, tags }) => {
+
+                // If the type is ignored or internal, don't document it
+                if (tags.has('ignore') || tags.has('internal')) {
+                  return null;
+                }
+                
+                // Resolve each type to a URL
+                const resolvedTypes = types.map(type => {
+                  if (type.moduleName === 'playcanvas') {
+                    return {
+                      name: type.name,
+                      url: `https://api.playcanvas.com/engine/classes/${type.name}.html`
+                    };
+                  }
+
+                  // No URL for this type
+                  return { name: type.name, url: null };
+                });
+                
+                return {
+                  displayName,
+                  types: resolvedTypes
+                };
+              }
+            }]
+          ],
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:
@@ -278,5 +309,6 @@ const config = {
       },
     }),
 };
+
 
 export default config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,9 @@
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "sass": "^1.93.2",
-        "sync-ammo": "^0.1.2"
+        "sync-ammo": "^0.1.2",
+        "ts-morph": "^27.0.0",
+        "unist-util-visit": "^5.0.0"
       },
       "devDependencies": {
         "@docusaurus/module-type-aliases": "^3.9.1",
@@ -4170,6 +4172,27 @@
         "mlly": "^1.7.4"
       }
     },
+    "node_modules/@isaacs/balanced-match": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
+      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@isaacs/brace-expansion": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
+      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@isaacs/balanced-match": "^4.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -5200,6 +5223,32 @@
       "license": "ISC",
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/@ts-morph/common": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.28.0.tgz",
+      "integrity": "sha512-4w6X/oFmvXcwux6y6ExfM/xSqMHw20cYwFJH+BlYrtGa6nwY9qGq8GXnUs1sVYeF2o/KT3S8hAH6sKBI3VOkBg==",
+      "license": "MIT",
+      "dependencies": {
+        "minimatch": "^10.0.1",
+        "path-browserify": "^1.0.1",
+        "tinyglobby": "^0.2.14"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/minimatch": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
+      "integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
+      "license": "ISC",
+      "dependencies": {
+        "@isaacs/brace-expansion": "^5.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@types/body-parser": {
@@ -7129,6 +7178,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/code-block-writer": {
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-13.0.3.tgz",
+      "integrity": "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==",
+      "license": "MIT"
     },
     "node_modules/collapse-white-space": {
       "version": "2.1.0",
@@ -14734,6 +14789,12 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "license": "MIT"
+    },
     "node_modules/path-data-parser": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
@@ -18868,6 +18929,51 @@
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.1.tgz",
       "integrity": "sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw=="
     },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/tinypool": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
@@ -18952,6 +19058,16 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "license": "Apache-2.0"
     },
+    "node_modules/ts-morph": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-27.0.0.tgz",
+      "integrity": "sha512-xcqelpTR5PCuZMs54qp9DE3t7tPgA2v/P1/qdW4ke5b3Y5liTGTYj6a/twT35EQW/H5okRqp1UOqwNlgg0K0eQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@ts-morph/common": "~0.28.0",
+        "code-block-writer": "^13.0.3"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -19021,6 +19137,21 @@
       "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
       "dependencies": {
         "is-typedarray": "^1.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/uc.micro": {
@@ -19181,6 +19312,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
       "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+      "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
         "unist-util-is": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,9 @@
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "sass": "^1.93.2",
-    "sync-ammo": "^0.1.2"
+    "sync-ammo": "^0.1.2",
+    "ts-morph": "^27.0.0",
+    "unist-util-visit": "^5.0.0"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^3.9.1",

--- a/sidebars.js
+++ b/sidebars.js
@@ -302,15 +302,26 @@ const sidebars = {
         {
           type: 'category',
           label: 'API',
-          // link: {
-          //   type: 'doc',
-          //   id: 'user-manual/playcanvas-react/guide/index',
-          // },
           items: [
             'user-manual/playcanvas-react/api/application',
-            // 'user-manual/playcanvas-react/guide/loading-assets',
-            // 'user-manual/playcanvas-react/guide/physics',
-            // 'user-manual/playcanvas-react/guide/materials'
+            'user-manual/playcanvas-react/api/entity',
+            {
+              type: 'category',
+              label: 'Components',
+              key: 'react-api-components',
+              items: [
+                'user-manual/playcanvas-react/api/align',
+                'user-manual/playcanvas-react/api/anim',
+                'user-manual/playcanvas-react/api/camera',
+                'user-manual/playcanvas-react/api/collision',
+                'user-manual/playcanvas-react/api/environment',
+                'user-manual/playcanvas-react/api/gsplat',
+                'user-manual/playcanvas-react/api/light',
+                'user-manual/playcanvas-react/api/render',
+                'user-manual/playcanvas-react/api/rigidbody',
+                'user-manual/playcanvas-react/api/script',
+              ]
+            }
           ]
         },
         

--- a/sidebars.js
+++ b/sidebars.js
@@ -298,7 +298,22 @@ const sidebars = {
             'user-manual/playcanvas-react/guide/physics',
             'user-manual/playcanvas-react/guide/materials'
           ]
-        }
+        },
+        {
+          type: 'category',
+          label: 'API',
+          // link: {
+          //   type: 'doc',
+          //   id: 'user-manual/playcanvas-react/guide/index',
+          // },
+          items: [
+            'user-manual/playcanvas-react/api/application',
+            // 'user-manual/playcanvas-react/guide/loading-assets',
+            // 'user-manual/playcanvas-react/guide/physics',
+            // 'user-manual/playcanvas-react/guide/materials'
+          ]
+        },
+        
       ],
     },
     {

--- a/src/components/playcanvas-react/RenderApiDocs.css
+++ b/src/components/playcanvas-react/RenderApiDocs.css
@@ -1,0 +1,86 @@
+/* src/components/playcanvas-react/RenderApiDocs.css */
+
+/* Error state */
+.api-docs-error {
+  padding: 1rem;
+  border: 1px solid var(--ifm-color-danger);
+  border-radius: var(--ifm-border-radius);
+  background: var(--ifm-color-danger-contrast-background);
+  color: var(--ifm-color-danger-contrast-foreground);
+}
+
+/* Definition container */
+.api-docs-definition {
+  margin-bottom: 2rem;
+  border: 1px solid var(--ifm-border-color);
+  border-radius: var(--ifm-border-radius);
+  overflow: hidden;
+}
+
+/* Properties table */
+.api-docs-properties {
+  background: var(--ifm-background-color);
+}
+
+.api-docs-properties table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 0;
+}
+
+.api-docs-properties th {
+  background: transparent;
+  padding: 0.75rem;
+  text-align: left;
+  font-weight: 600;
+  border: 1px solid var(--ifm-border-color);
+}
+
+.api-docs-properties td {
+  padding: 0.75rem;
+  border: 1px solid var(--ifm-border-color);
+  vertical-align: top;
+}
+
+.api-docs-properties tr:nth-child(even) {
+  background: var(--ifm-color-emphasis-25);
+}
+
+.api-docs-properties tr:hover {
+  background: var(--ifm-color-emphasis-50);
+}
+
+/* Type cell with inline description */
+.type-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.type-cell code {
+  display: inline;
+  width: fit-content;
+  padding: 0 .5rem
+}
+
+/* Type description below the type */
+.type-description {
+  font-size: 0.875rem;
+  color: var(--ifm-color-emphasis-700);
+  line-height: 1.4;
+  margin-top: 0.5rem;
+  font-weight: normal;
+}
+
+/* Dark mode adjustments */
+[data-theme='dark'] .api-docs-properties tr:nth-child(even) {
+  background: var(--ifm-color-emphasis-100);
+}
+
+[data-theme='dark'] .api-docs-properties tr:hover {
+  background: var(--ifm-color-emphasis-200);
+}
+
+[data-theme='dark'] .api-docs-properties th {
+  background: transparent;
+}

--- a/src/components/playcanvas-react/RenderApiDocs.jsx
+++ b/src/components/playcanvas-react/RenderApiDocs.jsx
@@ -1,0 +1,162 @@
+// src/components/playcanvas-react/RenderApiDocs.jsx
+import React from 'react';
+import './RenderApiDocs.css';
+
+/**
+ * Main component to render API documentation from parsed TypeScript types
+ * Data comes pre-parsed from the remark plugin at build time
+ */
+export default function RenderApiDocs({ data }) {
+  const definitions = parseData(data);
+  
+  if (!definitions || definitions.length === 0) {
+    return <div className="api-docs-error">No API data available</div>;
+  }
+  
+  return (
+    <>
+      {definitions.map((definition, index) => (
+        <div className="api-docs-definition">
+          { definition.entries?.length > 0 && (
+            <PropertyTable entries={definition.entries} />
+          )}
+        </div>
+      ))}
+    </>
+  );
+}
+
+/**
+ * Parse the JSON data if it's a string
+ */
+function parseData(data) {
+  if (!data) return null;
+  
+  if (typeof data === 'string') {
+    try {
+      return JSON.parse(data);
+    } catch (error) {
+      console.error('Error parsing API data:', error);
+      return null;
+    }
+  }
+  
+  return parsedData;
+}
+
+/**
+ * Render a table of properties
+ */
+function PropertyTable({ entries }) {
+  return (
+    <div className="api-docs-properties">
+      <table>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Default</th>
+          </tr>
+        </thead>
+        <tbody>
+          {entries.map((entry, index) => (
+            <PropertyRow key={index} entry={entry} />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+/**
+ * Render a single property row
+ */
+function PropertyRow({ entry }) {
+  return (
+    <tr>
+      <td>
+        <code>
+          {entry.name}{entry.optional ? '?' : ''}
+        </code>
+      </td>
+      <td>
+        <div className="type-cell">
+          <TypeDisplay type={entry.type} />
+          {entry.description && (
+            <div className="type-description">{entry.description}</div>
+          )}
+        </div>
+      </td>
+      <td>
+        <code>{entry.defaultValue || '-'}</code>
+      </td>
+    </tr>
+  );
+}
+
+/**
+ * Render type information with proper linking
+ * Supports both simple types and union types with individual links
+ */
+function TypeDisplay({ type }) {
+  if (!type) {
+    return <code>unknown</code>;
+  }
+  
+  // New format: { displayName, types: [{ name, url }, ...] }
+  if (type.displayName && type.types) {
+    return <UnionType displayName={type.displayName} types={type.types} />;
+  }
+  
+  // Old/simple format: { name, url }
+  return <SimpleType name={type.name || 'unknown'} url={type.url} />;
+}
+
+/**
+ * Render a union type with individual links for each member
+ */
+function UnionType({ displayName, types }) {
+  // If no linkable types, just show the display name
+  if (!types.some(t => t.url)) {
+    return <code>{displayName}</code>;
+  }
+  
+  const parts = displayName.split(/\s*\|\s*/);
+  
+  return (
+    <code>
+      {parts.map((part, index) => {
+        const trimmedPart = part.trim();
+        const matchingType = types.find(t => t.name === trimmedPart);
+        
+        return (
+          <React.Fragment key={index}>
+            {index > 0 && ' | '}
+            {matchingType?.url ? (
+              <a href={matchingType.url} target="_blank" rel="noopener noreferrer">
+                {trimmedPart}
+              </a>
+            ) : (
+              trimmedPart
+            )}
+          </React.Fragment>
+        );
+      })}
+    </code>
+  );
+}
+
+/**
+ * Render a simple type with optional link
+ */
+function SimpleType({ name, url }) {
+  if (url) {
+    return (
+      <a href={url} target="_blank" rel="noopener noreferrer">
+        <code>{name}</code>
+      </a>
+    );
+  }
+  
+  return <code>{name}</code>;
+}

--- a/src/theme/MDXComponents.js
+++ b/src/theme/MDXComponents.js
@@ -1,0 +1,9 @@
+// src/theme/MDXComponents.js
+import React from 'react';
+import MDXComponents from '@theme-original/MDXComponents';
+import RenderApiDocs from '@site/src/components/playcanvas-react/RenderApiDocs';
+
+export default {
+  ...MDXComponents,
+  RenderApiDocs,
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,33 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "exactOptionalPropertyTypes": true,
+    "strictNullChecks": true,
+    "baseUrl": ".",
+    "paths": {
+      "@site/*": ["./src/*"]
+    }
+  },
+  "include": [
+    "src/**/*",
+    "docs/**/*",
+    "utils/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "build",
+    ".docusaurus"
+  ]
+}

--- a/utils/plugins/remark-typedoc.mjs
+++ b/utils/plugins/remark-typedoc.mjs
@@ -1,0 +1,246 @@
+// utils/plugins/remark-tsdoc-simple.mjs
+import { visit } from 'unist-util-visit';
+import { Project, SyntaxKind, ts } from 'ts-morph';
+
+/**
+ * This is a docusaurus plugin the parse TS Code blocks and extract API documentation.
+ * Use in conjunction with the RenderApiDocs component to display the TSDocs.
+ * 
+ * @example
+ * ```tsx asTypedoc
+ * export MyType = {
+ *   // The is the name property
+ *   name: string;
+ *   // The age property is optional
+ *   age?: number;
+ * }
+ * ```
+ * 
+ * This will render a Type doc style component
+ */
+
+/**
+ * The symbol to use to denote that the code block should be rendered as documentation
+ */
+const DOC_SYMBOL = 'asTypedoc';
+
+/**
+ * @typedef {Object} PropertyType
+ * Defines a type with a name, and the module that it belongs to
+ * @param {string} name - The name of the type
+ * @param {string} moduleName - The name of the module
+*/
+
+/**
+ * @typedef {Function} TypeResolver
+ * A function that allows users to map documented types to custom URLs
+ * @param {Object} options - The options for generating definitions
+ * @param {string} options.displayName - The name of the type
+ * @param {PropertyType[]} options.types - The types of the type
+ * @param {Map<string, string>} options.tags - The JSDoc tags for the type
+*/
+
+/**
+ * @typedef {Object} Definition
+ * @param {string} name - The name of the type
+ * @param {string} description - The description of the type
+ * @param {Entry[]} entries - The entries for the type
+*/
+
+/**
+ * @typedef {Object} Entry
+ * @param {string} name - The name of the entry
+ * @param {Object} type - The type of the entry
+ * @param {string} description - The description of the entry
+ * @param {boolean} optional - Whether the entry is optional
+ * @param {string} defaultValue - The default value of the entry
+*/
+
+let compilerObject;
+
+// Create a single project instance (like Nextra does)
+const project = new Project({
+  tsConfigFilePath: './tsconfig.json',
+  skipAddingFilesFromTsConfig: true,
+  compilerOptions: {
+    exactOptionalPropertyTypes: true,
+    strictNullChecks: true,
+    skipLibCheck: true,
+    moduleResolution: 2, // Node
+    esModuleInterop: true,
+    allowSyntheticDefaultImports: true,
+  },
+});
+
+/**
+ * Remark plugin to parse TypeScript code blocks and extract API documentation
+ * Uses ts-morph for robust TypeScript parsing
+ * @param {Object} options - The options for generating definitions
+ * @param {TypeResolver} options.typeResolver - A function to resolve types
+ */
+export default function remarkTypedoc({ typeResolver }) {
+  return async (tree) => {
+    visit(tree, 'code', async (node, index, parent) => {
+      if ((node.lang === 'tsx' || node.lang === 'ts') && node.meta?.includes(DOC_SYMBOL)) {
+        try {
+
+          const definitions = generateDefinitions({
+            code: node.value,
+            typeResolver
+          });          
+
+          parent.children[index] = {
+            type: 'mdxJsxTextElement',
+            name: 'RenderApiDocs',
+            attributes: [{
+              type: 'mdxJsxAttribute',
+              name: 'data',
+              value: JSON.stringify(definitions)
+            }],
+            children: []
+          };
+
+        } catch (error) {
+          console.error('Error processing tsdoc code block:', error);
+        }
+      }
+    });
+  };
+}
+
+/**
+ * Generate documentation for all exported members (types, interfaces, etc.)
+ * @param {Object} options - The options for generating definitions
+ * @param {string} options.code - The code to generate definitions for
+ * @param {TypeResolver} options.typeResolver - A function to resolve types
+ * @returns {Array} An array of definitions
+ */
+function generateDefinitions({ code, typeResolver }) {
+  compilerObject ??= project.getTypeChecker().compilerObject;
+  const sourceFile = project.createSourceFile('temp.tsx', code, { overwrite: true });
+  const exportedDeclarations = sourceFile.getExportedDeclarations();
+  const definitions = [];
+
+  // Run through all exported declarations
+  for (const [name, declarations] of exportedDeclarations) {
+    const declaration = declarations[0];
+    const symbol = declaration.getSymbol()
+    const description = getComment(symbol);
+    const properties = declaration.getType().getApparentProperties();
+    
+    // Run through the exports properties
+    const entries = properties
+      .map(symbol => getDocEntry({ symbol, declaration, typeResolver }))
+      .filter(({ type }) => !!type); // Ignore properties with no type
+
+    // Add the definition to the definitions array
+    definitions.push({ name, description, entries });
+  };
+
+  return definitions;
+}
+
+/**
+ * Get comment and tags from symbol
+ */
+function getComment(symbol) {
+  if (!symbol) {
+    return ''
+  }
+  const comment = symbol.compilerSymbol.getDocumentationComment(compilerObject);
+  return ts.displayPartsToString(comment);
+}
+
+/**
+ * Get documentation entry for a symbol
+ * @param {Object} options - The options for generating definitions
+ * @param {Object} options.symbol - The symbol for the type
+ * @param {Object} options.declaration - The declaration for the type
+ * @param {TypeResolver} options.typeResolver - A function to resolve types
+ * @returns {Entry} The documentation entry for the symbol
+ */
+function getDocEntry({ symbol, declaration, typeResolver = noop }) {
+
+  // get internal properties
+  const subType = symbol.getTypeAtLocation(declaration);
+  const valueDeclaration = symbol.getValueDeclaration();
+  const isFunctionParameter = valueDeclaration && valueDeclaration.getKind() === SyntaxKind.Parameter;
+  
+  // get entry properties
+  const name = symbol.getName();
+  const comments = getComment(symbol);// ?? getComment(declaration.getType().getAliasSymbol());
+  const description = replaceJsDocLinks(comments)//.replace(/^- /, '');
+  const optional = isFunctionParameter ? valueDeclaration.isOptional() : symbol.isOptional();
+  const tags = getTags(symbol);
+  const defaultValue = subType.getDefault() ?? tags.get('default') ?? tags.get('defaultValue');
+  const typeName = getTypeName({ symbol, subType, valueDeclaration });
+
+  // Extract the type information
+  const typesToProcess = subType.isUnion() 
+    ? subType.getUnionTypes().filter(t => !t.isNull() && !t.isUndefined())
+    : [subType];
+  
+  // Extract the name and module names for the types
+  const types = typesToProcess.map(t => {
+    const sym = t.getSymbol();
+    const sourceFile = sym?.getDeclarations()[0]?.getSourceFile();
+    return {
+      name: sym?.getName() || t.getText(),
+      moduleName: sourceFile?.getBaseNameWithoutExtension()
+    };
+  });
+  
+  const type = typeResolver({ displayName: typeName, types, tags });
+  
+  return {
+    name,
+    description,
+    optional,
+    defaultValue,
+    type
+  };
+}
+
+/**
+ * Get type name for a symbol
+ * @param {Object} options - The options for generating definitions
+ * @param {Object} options.symbol - The symbol for the type
+ * @param {Object} options.subType - The sub type for the type
+ * @param {Object} options.valueDeclaration - The value declaration for the type
+ * @returns {string} The type name for the symbol
+ */
+function getTypeName({ symbol, subType, valueDeclaration }) {  
+  const typeOf = valueDeclaration?.getType() ?? symbol.getDeclaredType();
+  return typeOf.isUnknown() ? 'unknown' : getFormattedText(subType);
+}
+
+/**
+ * Get JSDoc tags from symbol
+ * @param {Object} options - The options for generating definitions
+ * @param {Object} options.symbol - The symbol for the type
+ * @returns {Map<string, string>} The JSDoc tags for the symbol
+ */
+const getTags = (symbol) => {
+  const tags = new Map();
+  symbol.getJsDocTags().forEach(tag => 
+    tags.set(tag.getName(), ts.displayPartsToString(tag.getText()))
+  );
+  return tags;
+};
+
+/**
+ * Get formatted text from type
+ * @param {Object} t - The type to get the formatted text from
+ * @returns {string} The formatted text from the type
+ */
+const getFormattedText = (t) => t.getText(undefined, ts.TypeFormatFlags.UseAliasDefinedOutsideCurrentScope);
+
+/**
+ * Replace JSDoc links
+ * @param {string} md - The markdown to replace links in
+ * @returns {string} The markdown with links replaced
+ */
+const replaceJsDocLinks = (md) => md.replaceAll(/{@link (?<link>[^}]*)}/g, '$1');
+
+
+const noop = (a) => a;


### PR DESCRIPTION
This PR adds API documentation for PlayCanvas React. It includes all exported components and hooks. The API docs are generated from the installed @playcanvas/react, meaning that the docs will always reflect the API of the currently installed version.

<img width="1437" height="1407" alt="image" src="https://github.com/user-attachments/assets/da526ab8-af6a-4086-b968-e0160ab60c2d" />

## Tasks

- [x] **Core** - `Application`, `Entity`
- [x] **Components** - `Camera`, `Light`, `Render`, `Environment`, `Collision`, `RigidBody`, `Anim`, `Gsplat`, `Script`, `Align`
- [ ] **Hooks** - `useAsset`, `useApp`, `useAppEvent`, `usePhysics`

## Features

- Introduce a new remark plugin (`typedoc`) to parse TypeScript code blocks and extract API documentation.
- Implement `RenderApiDocs` component to render parsed API documentation.
- Update Docusaurus configuration to include the new plugin and enhance markdown processing.
- Add new API documentation for the `Application` component in PlayCanvas React.
- Create a new `tsconfig.json` for TypeScript support.
- Add styles for API documentation rendering.
- Update sidebars to include a new API section for better navigation.

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/developer.playcanvas.com/blob/main/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
