### PR TITLE
Update installation command from npx to npm

### DIFF
--- a/docs/user-manual/playcanvas-react/getting-started/installation.md
+++ b/docs/user-manual/playcanvas-react/getting-started/installation.md
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 The recommended way to get started is to use the official PlayCanvas scaffolding tool, and follow the prompts.
 
 ```bash
-npx create playcanvas@latest -t react-ts
+npm create playcanvas@latest -t react-ts
 ```
 
 This creates a new project with everything set up and ready to go. If you've followed the prompts, you'll have a new PlayCanvas React project running in your browser.


### PR DESCRIPTION
Use `npm create` instead of `npx create` (which was asking to install the `create` package.)

The [`create`](https://www.npmjs.com/package/create) package explicitly warns to use `npm create` instead of `npx create`

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/developer.playcanvas.com/blob/main/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
