### PR TITLE
Document shadow and picker pass support for ShaderMaterial

### DIFF
--- a/docs/user-manual/graphics/shaders/index.md
+++ b/docs/user-manual/graphics/shaders/index.md
@@ -204,6 +204,70 @@ For more complete examples, and also for details on how to implement instancing,
 
 :::
 
+#### Shadow Pass {#shadow-pass}
+
+To allow meshes using your custom shader to cast shadows, the fragment shader needs to output data appropriate for the shadow type being rendered during the shadow pass. Include the engine-provided `shadowCasterPS` chunk when `SHADOW_PASS` is defined, and write the value returned by `getShadowOutput()` to the output color:
+
+```glsl
+#ifdef SHADOW_PASS
+    // Provides getShadowOutput(), which returns the data for the shadow type being rendered
+    #include "shadowCasterPS"
+#endif
+
+void main(void)
+{
+    #ifdef SHADOW_PASS
+
+        // output shadow data (alpha-tested materials can discard before this)
+        gl_FragColor = getShadowOutput();
+
+    #else
+
+        // normal color rendering
+        gl_FragColor = ...;
+
+    #endif
+}
+```
+
+In WGSL, the equivalent is `output.color = getShadowOutput();`.
+
+The same vertex shader is used when rendering shadows, so skinning, morphing and instancing handled by `transformCoreVS` work automatically. It is recommended to skip work not needed by shadow rendering (for example lighting) using `#ifndef SHADOW_PASS`, to make the shadow rendering faster. Note that some engine uniforms, such as `matrix_normal`, are not available during the shadow pass.
+
+Supported are all shadow types for directional lights, and PCF shadows for spot lights. Omni light shadows are not supported.
+
+:::note
+
+For a complete example, see the Shader Material Shadows example in the engine examples browser.
+
+:::
+
+#### Picker Pass {#picker-pass}
+
+To allow meshes using your custom shader to be identified by the [`Picker`](https://api.playcanvas.com/engine/classes/Picker.html), the fragment shader needs to output the mesh instance ID during the pick pass. Include the engine-provided `pickPS` chunk when `PICK_PASS` is defined, and write the value returned by `getPickOutput()` to the output color:
+
+```glsl
+#ifdef PICK_PASS
+    // Provides getPickOutput(), which returns the encoded ID of the mesh instance
+    #include "pickPS"
+#endif
+
+void main(void)
+{
+    #ifdef PICK_PASS
+
+        // output the mesh instance ID
+        gl_FragColor = getPickOutput();
+
+    #else
+
+        // normal color rendering
+        gl_FragColor = ...;
+
+    #endif
+}
+```
+
 #### Generated Shaders {#generated-shaders}
 
 If you have a need to inspect the generated shaders, you can add this to your script

--- a/docs/user-manual/graphics/shaders/index.md
+++ b/docs/user-manual/graphics/shaders/index.md
@@ -3,6 +3,9 @@ title: Shaders
 description: Author ShaderMaterial with paired GLSL and WGSL, declare attributes, and integrate with the engine shader system.
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 When you import your 3D models into PlayCanvas, by default, they will use our [Physical Material](/user-manual/graphics/physical-rendering/physical-materials/). This is a versatile material type that can cover a lot of your rendering needs.
 
 However, you will often want to perform special effects or special cases for your materials. To do this you will need to write a custom shader. In this case, you need to use `ShaderMaterial`.
@@ -127,6 +130,9 @@ The engine provides predefined shader includes that handle common transformation
 
 For example:
 
+<Tabs groupId="shader-language" queryString="lang">
+<TabItem value="glsl" label="GLSL">
+
 ```glsl
 // Includes transformation-related functionality provided by the engine.
 // - Automatically declares the `vertex_position` attribute.
@@ -168,11 +174,66 @@ void main(void)
 }
 ```
 
+</TabItem>
+<TabItem value="wgsl" label="WGSL">
+
+```wgsl
+// Includes transformation-related functionality provided by the engine.
+// - Automatically declares the `vertex_position` attribute.
+// - Handles skinning and morphing if necessary.
+// - Adds the following uniforms:
+//   - `matrix_viewProjection`
+//   - `matrix_model`
+//   - `matrix_normal`
+// - Provides utility functions:
+//   - `getModelMatrix()`
+//   - `getLocalPosition()`
+#include "transformCoreVS"
+
+// Includes normal-related functionality provided by the engine.
+// - Automatically declares the `vertex_normal` attribute.
+// - Handles skinning and morphing if necessary.
+// - Provides utility functions:
+//   - `getNormalMatrix()`
+//   - `getLocalNormal()`
+#include "normalCoreVS"
+
+@vertex
+fn vertexMain(input: VertexInput) -> VertexOutput
+{
+    var output: VertexOutput;
+
+    // Retrieve the model matrix, accounting for skinning, morphing, or instancing.
+    let modelMatrix: mat4x4f = getModelMatrix();
+    let localPos: vec3f = getLocalPosition(vertex_position.xyz);
+    let worldPos: vec4f = modelMatrix * vec4f(localPos, 1.0);
+
+    // Retrieve the normal matrix and compute the world normal.
+    let normalMatrix: mat3x3f = getNormalMatrix(modelMatrix);
+    let localNormal: vec3f = getLocalNormal(vertex_normal);
+    let worldNormal: vec3f = normalize(normalMatrix * localNormal);
+
+    // Example: Apply simple wrap-around diffuse lighting using the world normal.
+    output.brightness = (dot(worldNormal, uniform.uLightDir) + 1.0) * 0.5;
+
+    // Transform the geometry.
+    output.position = uniform.matrix_viewProjection * worldPos;
+
+    return output;
+}
+```
+
+</TabItem>
+</Tabs>
+
 #### Fragment Shader {#fragment-shader}
 
 The engine provides predefined shader chunks you can include for common color processing effects such as gamma correction, tone mapping and fog. These includes ensure that colors are processed correctly according to the rendering settings.
 
 Example Usage
+
+<Tabs groupId="shader-language" queryString="lang">
+<TabItem value="glsl" label="GLSL">
 
 ```glsl
 #include "gammaPS"       // Adds support for gamma correction of inputs and outputs
@@ -196,6 +257,38 @@ void main(void)
 }
 ```
 
+</TabItem>
+<TabItem value="wgsl" label="WGSL">
+
+```wgsl
+#include "gammaPS"       // Adds support for gamma correction of inputs and outputs
+#include "tonemappingPS" // Adds support for tone mapping
+#include "fogPS"         // Adds support for fog effects
+
+@fragment
+fn fragmentMain(input: FragmentInput) -> FragmentOutput
+{
+    var output: FragmentOutput;
+
+    // Evaluate color in linear color space
+    let colorLinear: vec3f = ...;
+
+    // Apply fog if enabled
+    let fogged: vec3f = addFog(colorLinear);
+
+    // Apply tone mapping if enabled
+    let toneMapped: vec3f = toneMap(fogged);
+
+    // Apply gamma correction and output the final color
+    output.color = vec4f(gammaCorrectOutput(toneMapped), alpha);
+
+    return output;
+}
+```
+
+</TabItem>
+</Tabs>
+
 These functions are automatically configured based on the engine's settings, ensuring that color processing is consistent across different rendering conditions.
 
 :::note
@@ -207,6 +300,9 @@ For more complete examples, and also for details on how to implement instancing,
 #### Shadow Pass {#shadow-pass}
 
 To allow meshes using your custom shader to cast shadows, the fragment shader needs to output data appropriate for the shadow type being rendered during the shadow pass. Include the engine-provided `shadowCasterPS` chunk when `SHADOW_PASS` is defined, and write the value returned by `getShadowOutput()` to the output color:
+
+<Tabs groupId="shader-language" queryString="lang">
+<TabItem value="glsl" label="GLSL">
 
 ```glsl
 #ifdef SHADOW_PASS
@@ -230,7 +326,38 @@ void main(void)
 }
 ```
 
-In WGSL, the equivalent is `output.color = getShadowOutput();`.
+</TabItem>
+<TabItem value="wgsl" label="WGSL">
+
+```wgsl
+#ifdef SHADOW_PASS
+    // Provides getShadowOutput(), which returns the data for the shadow type being rendered
+    #include "shadowCasterPS"
+#endif
+
+@fragment
+fn fragmentMain(input: FragmentInput) -> FragmentOutput
+{
+    var output: FragmentOutput;
+
+    #ifdef SHADOW_PASS
+
+        // output shadow data (alpha-tested materials can discard before this)
+        output.color = getShadowOutput();
+
+    #else
+
+        // normal color rendering
+        output.color = ...;
+
+    #endif
+
+    return output;
+}
+```
+
+</TabItem>
+</Tabs>
 
 The same vertex shader is used when rendering shadows, so skinning, morphing and instancing handled by `transformCoreVS` work automatically. It is recommended to skip work not needed by shadow rendering (for example lighting) using `#ifndef SHADOW_PASS`, to make the shadow rendering faster. Note that some engine uniforms, such as `matrix_normal`, are not available during the shadow pass.
 
@@ -245,6 +372,9 @@ For a complete example, see the Shader Material Shadows example in the engine ex
 #### Picker Pass {#picker-pass}
 
 To allow meshes using your custom shader to be identified by the [`Picker`](https://api.playcanvas.com/engine/classes/Picker.html), the fragment shader needs to output the mesh instance ID during the pick pass. Include the engine-provided `pickPS` chunk when `PICK_PASS` is defined, and write the value returned by `getPickOutput()` to the output color:
+
+<Tabs groupId="shader-language" queryString="lang">
+<TabItem value="glsl" label="GLSL">
 
 ```glsl
 #ifdef PICK_PASS
@@ -267,6 +397,39 @@ void main(void)
     #endif
 }
 ```
+
+</TabItem>
+<TabItem value="wgsl" label="WGSL">
+
+```wgsl
+#ifdef PICK_PASS
+    // Provides getPickOutput(), which returns the encoded ID of the mesh instance
+    #include "pickPS"
+#endif
+
+@fragment
+fn fragmentMain(input: FragmentInput) -> FragmentOutput
+{
+    var output: FragmentOutput;
+
+    #ifdef PICK_PASS
+
+        // output the mesh instance ID
+        output.color = getPickOutput();
+
+    #else
+
+        // normal color rendering
+        output.color = ...;
+
+    #endif
+
+    return output;
+}
+```
+
+</TabItem>
+</Tabs>
 
 #### Generated Shaders {#generated-shaders}
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/shaders/index.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/shaders/index.md
@@ -3,6 +3,9 @@ title: シェーダー
 description: 対になる GLSL と WGSL で ShaderMaterial を記述し、attribute を宣言してエンジンのシェーダーシステムに統合します。
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 3DモデルをPlayCanvasにインポートすると、デフォルトで当社の[Physical Material](/user-manual/graphics/physical-rendering/physical-materials/)が使用されます。これは、レンダリングの多くのニーズをカバーできる多用途なマテリアルタイプです。
 
 しかし、マテリアルに特殊効果や特殊なケースを適用したいと思うことがよくあります。これを行うには、カスタムシェーダーを記述する必要があります。この場合、`ShaderMaterial`を使用する必要があります。
@@ -119,6 +122,9 @@ camera.setShaderPass('custom');
 
 例：
 
+<Tabs groupId="shader-language" queryString="lang">
+<TabItem value="glsl" label="GLSL">
+
 ```glsl
 // エンジンが提供する変換関連の機能を含みます。
 // - `vertex_position`アトリビュートを自動的に宣言します。
@@ -160,11 +166,66 @@ void main(void)
 }
 ```
 
+</TabItem>
+<TabItem value="wgsl" label="WGSL">
+
+```wgsl
+// エンジンが提供する変換関連の機能を含みます。
+// - `vertex_position`アトリビュートを自動的に宣言します。
+// - 必要に応じてスキニングとモーフィングを処理します。
+// - 以下のユニフォームを追加します：
+//   - `matrix_viewProjection`
+//   - `matrix_model`
+//   - `matrix_normal`
+// - ユーティリティ関数を提供します：
+//   - `getModelMatrix()`
+//   - `getLocalPosition()`
+#include "transformCoreVS"
+
+// エンジンが提供する法線関連の機能を含みます。
+// - `vertex_normal`アトリビュートを自動的に宣言します。
+// - 必要に応じてスキニングとモーフィングを処理します。
+// - ユーティリティ関数を提供します：
+//   - `getNormalMatrix()`
+//   - `getLocalNormal()`
+#include "normalCoreVS"
+
+@vertex
+fn vertexMain(input: VertexInput) -> VertexOutput
+{
+    var output: VertexOutput;
+
+    // スキニング、モーフィング、またはインスタンス化を考慮してモデル行列を取得します。
+    let modelMatrix: mat4x4f = getModelMatrix();
+    let localPos: vec3f = getLocalPosition(vertex_position.xyz);
+    let worldPos: vec4f = modelMatrix * vec4f(localPos, 1.0);
+
+    // 法線行列を取得し、ワールド法線を計算します。
+    let normalMatrix: mat3x3f = getNormalMatrix(modelMatrix);
+    let localNormal: vec3f = getLocalNormal(vertex_normal);
+    let worldNormal: vec3f = normalize(normalMatrix * localNormal);
+
+    // 例：ワールド法線を使用してシンプルなラップアラウンド拡散ライティングを適用します。
+    output.brightness = (dot(worldNormal, uniform.uLightDir) + 1.0) * 0.5;
+
+    // ジオメトリを変換します。
+    output.position = uniform.matrix_viewProjection * worldPos;
+
+    return output;
+}
+```
+
+</TabItem>
+</Tabs>
+
 #### フラグメントシェーダー {#fragment-shader}
 
 エンジンは、ガンマ補正、トーンマッピング、フォグなどの一般的な色処理効果のために含めることができる事前定義されたシェーダーチャンクを提供します。これらのインクルードにより、レンダリング設定に従って色が正しく処理されます。
 
 使用例
+
+<Tabs groupId="shader-language" queryString="lang">
+<TabItem value="glsl" label="GLSL">
 
 ```glsl
 #include "gammaPS"       // 入出力のガンマ補正をサポートします
@@ -188,6 +249,38 @@ void main(void)
 }
 ```
 
+</TabItem>
+<TabItem value="wgsl" label="WGSL">
+
+```wgsl
+#include "gammaPS"       // 入出力のガンマ補正をサポートします
+#include "tonemappingPS" // トーンマッピングをサポートします
+#include "fogPS"         // フォグ効果をサポートします
+
+@fragment
+fn fragmentMain(input: FragmentInput) -> FragmentOutput
+{
+    var output: FragmentOutput;
+
+    // リニアカラースペースで色を評価します
+    let colorLinear: vec3f = ...;
+
+    // 有効な場合はフォグを適用します
+    let fogged: vec3f = addFog(colorLinear);
+
+    // 有効な場合はトーンマッピングを適用します
+    let toneMapped: vec3f = toneMap(fogged);
+
+    // ガンマ補正を適用し、最終的な色を出力します
+    output.color = vec4f(gammaCorrectOutput(toneMapped), alpha);
+
+    return output;
+}
+```
+
+</TabItem>
+</Tabs>
+
 これらの関数はエンジンの設定に基づいて自動的に構成され、異なるレンダリング条件下でも色処理が一貫していることを保証します。
 
 :::note
@@ -199,6 +292,9 @@ void main(void)
 #### シャドウパス {#shadow-pass}
 
 カスタムシェーダーを使用するメッシュがシャドウをキャストできるようにするには、シャドウパス中に、レンダリングされるシャドウタイプに応じたデータをフラグメントシェーダーから出力する必要があります。`SHADOW_PASS`が定義されている場合にエンジン提供の`shadowCasterPS`チャンクをインクルードし、`getShadowOutput()`が返す値を出力カラーに書き込みます:
+
+<Tabs groupId="shader-language" queryString="lang">
+<TabItem value="glsl" label="GLSL">
 
 ```glsl
 #ifdef SHADOW_PASS
@@ -222,7 +318,38 @@ void main(void)
 }
 ```
 
-WGSLでは、同等の処理は`output.color = getShadowOutput();`です。
+</TabItem>
+<TabItem value="wgsl" label="WGSL">
+
+```wgsl
+#ifdef SHADOW_PASS
+    // レンダリングされるシャドウタイプに応じたデータを返すgetShadowOutput()を提供します
+    #include "shadowCasterPS"
+#endif
+
+@fragment
+fn fragmentMain(input: FragmentInput) -> FragmentOutput
+{
+    var output: FragmentOutput;
+
+    #ifdef SHADOW_PASS
+
+        // シャドウデータを出力します(アルファテストを行うマテリアルはこの前にdiscardできます)
+        output.color = getShadowOutput();
+
+    #else
+
+        // 通常のカラーレンダリング
+        output.color = ...;
+
+    #endif
+
+    return output;
+}
+```
+
+</TabItem>
+</Tabs>
 
 シャドウのレンダリングには同じ頂点シェーダーが使用されるため、`transformCoreVS`によって処理されるスキニング、モーフィング、インスタンス化は自動的に機能します。シャドウレンダリングに不要な処理（例えばライティング）は`#ifndef SHADOW_PASS`を使用してスキップすることをお勧めします。これによりシャドウのレンダリングが高速になります。また、`matrix_normal`などの一部のエンジンユニフォームは、シャドウパス中には利用できないことに注意してください。
 
@@ -237,6 +364,9 @@ WGSLでは、同等の処理は`output.color = getShadowOutput();`です。
 #### ピッカーパス {#picker-pass}
 
 カスタムシェーダーを使用するメッシュを[`Picker`](https://api.playcanvas.com/engine/classes/Picker.html)で識別できるようにするには、ピックパス中にメッシュインスタンスIDをフラグメントシェーダーから出力する必要があります。`PICK_PASS`が定義されている場合にエンジン提供の`pickPS`チャンクをインクルードし、`getPickOutput()`が返す値を出力カラーに書き込みます:
+
+<Tabs groupId="shader-language" queryString="lang">
+<TabItem value="glsl" label="GLSL">
 
 ```glsl
 #ifdef PICK_PASS
@@ -259,6 +389,39 @@ void main(void)
     #endif
 }
 ```
+
+</TabItem>
+<TabItem value="wgsl" label="WGSL">
+
+```wgsl
+#ifdef PICK_PASS
+    // メッシュインスタンスのエンコードされたIDを返すgetPickOutput()を提供します
+    #include "pickPS"
+#endif
+
+@fragment
+fn fragmentMain(input: FragmentInput) -> FragmentOutput
+{
+    var output: FragmentOutput;
+
+    #ifdef PICK_PASS
+
+        // メッシュインスタンスIDを出力します
+        output.color = getPickOutput();
+
+    #else
+
+        // 通常のカラーレンダリング
+        output.color = ...;
+
+    #endif
+
+    return output;
+}
+```
+
+</TabItem>
+</Tabs>
 
 #### 生成されたシェーダー {#generated-shaders}
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/shaders/index.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/shaders/index.md
@@ -196,6 +196,70 @@ void main(void)
 
 :::
 
+#### シャドウパス {#shadow-pass}
+
+カスタムシェーダーを使用するメッシュがシャドウをキャストできるようにするには、シャドウパス中に、レンダリングされるシャドウタイプに応じたデータをフラグメントシェーダーから出力する必要があります。`SHADOW_PASS`が定義されている場合にエンジン提供の`shadowCasterPS`チャンクをインクルードし、`getShadowOutput()`が返す値を出力カラーに書き込みます:
+
+```glsl
+#ifdef SHADOW_PASS
+    // レンダリングされるシャドウタイプに応じたデータを返すgetShadowOutput()を提供します
+    #include "shadowCasterPS"
+#endif
+
+void main(void)
+{
+    #ifdef SHADOW_PASS
+
+        // シャドウデータを出力します(アルファテストを行うマテリアルはこの前にdiscardできます)
+        gl_FragColor = getShadowOutput();
+
+    #else
+
+        // 通常のカラーレンダリング
+        gl_FragColor = ...;
+
+    #endif
+}
+```
+
+WGSLでは、同等の処理は`output.color = getShadowOutput();`です。
+
+シャドウのレンダリングには同じ頂点シェーダーが使用されるため、`transformCoreVS`によって処理されるスキニング、モーフィング、インスタンス化は自動的に機能します。シャドウレンダリングに不要な処理（例えばライティング）は`#ifndef SHADOW_PASS`を使用してスキップすることをお勧めします。これによりシャドウのレンダリングが高速になります。また、`matrix_normal`などの一部のエンジンユニフォームは、シャドウパス中には利用できないことに注意してください。
+
+サポートされているのは、ディレクショナルライトのすべてのシャドウタイプと、スポットライトのPCFシャドウです。オムニライトのシャドウはサポートされていません。
+
+:::note
+
+完全な例については、エンジンのサンプルブラウザのShader Material Shadowsの例を参照してください。
+
+:::
+
+#### ピッカーパス {#picker-pass}
+
+カスタムシェーダーを使用するメッシュを[`Picker`](https://api.playcanvas.com/engine/classes/Picker.html)で識別できるようにするには、ピックパス中にメッシュインスタンスIDをフラグメントシェーダーから出力する必要があります。`PICK_PASS`が定義されている場合にエンジン提供の`pickPS`チャンクをインクルードし、`getPickOutput()`が返す値を出力カラーに書き込みます:
+
+```glsl
+#ifdef PICK_PASS
+    // メッシュインスタンスのエンコードされたIDを返すgetPickOutput()を提供します
+    #include "pickPS"
+#endif
+
+void main(void)
+{
+    #ifdef PICK_PASS
+
+        // メッシュインスタンスIDを出力します
+        gl_FragColor = getPickOutput();
+
+    #else
+
+        // 通常のカラーレンダリング
+        gl_FragColor = ...;
+
+    #endif
+}
+```
+
 #### 生成されたシェーダー {#generated-shaders}
 
 生成されたシェーダーを検査する必要がある場合は、これをスクリプトに追加できます


### PR DESCRIPTION
> [!WARNING]
> **Do not merge until engine 2.22 is released** — the `shadowCasterPS` chunk documented here ships with that release (playcanvas/engine#9116).

Adds two subsections to the Shader Includes section of the Shaders page (EN + JA):

**Changes:**
- **Shadow Pass** — how a `ShaderMaterial` fragment shader casts shadows using `#include "shadowCasterPS"` and `getShadowOutput()`, including the supported shadow types (all types for directional lights, PCF for spot lights, no omni), and the recommendation to skip forward-only work with `#ifndef SHADOW_PASS`.
- **Picker Pass** — how a `ShaderMaterial` fragment shader supports the `Picker` using `#include "pickPS"` and `getPickOutput()`. This feature is already available in released engine versions, but was previously undocumented.