### PR TITLE
Fix incorrect sRGB texture asset option in docs

### DIFF
--- a/docs/user-manual/graphics/linear-workflow/textures.md
+++ b/docs/user-manual/graphics/linear-workflow/textures.md
@@ -16,7 +16,7 @@ new pc.Asset(
     'color',
     'texture',
     { url: 'heart.png' },
-    { encoding: 'srgb' }
+    { srgb: true }
 );
 ```
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/linear-workflow/textures.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/linear-workflow/textures.md
@@ -16,7 +16,7 @@ new pc.Asset(
     'color',
     'texture',
     { url: 'heart.png' },
-    { encoding: 'srgb' }
+    { srgb: true }
 );
 ```
 


### PR DESCRIPTION
## Problem

The linear-workflow textures doc instructs loading an sRGB texture asset with:

```javascript
new pc.Asset('color', 'texture', { url: 'heart.png' }, { encoding: 'srgb' });
```

This is **wrong**. The engine's texture asset handler only reads a `srgb` boolean load option — there is no `encoding` key handling ([`texture.js:197`](https://github.com/playcanvas/engine/blob/main/src/framework/handlers/texture.js#L197)):

```javascript
if (assetData.hasOwnProperty('srgb')) {
    options.srgb = !!assetData.srgb;
}
```

So `{ encoding: 'srgb' }` is silently ignored and the texture loads as **linear**, appearing washed out / whiter. (`Texture.encoding` exists only as a read-only getter, which is likely the source of the confusion.)

Reported on the forum: https://forum.playcanvas.com/t/dynamically-loaded-texture-asset-appears-whiter-when-applied-to-ui/42518/2

## Fix

Use the correct option in both the EN and JA docs:

```javascript
new pc.Asset('color', 'texture', { url: 'heart.png' }, { srgb: true });
```

This matches the form already used elsewhere in the docs (`docs/user-manual/assets/custom-parsers.md`).
