### PR TITLE
Document how to aim directional and spot lights

### DIFF
--- a/docs/user-manual/graphics/lighting/lights.md
+++ b/docs/user-manual/graphics/lighting/lights.md
@@ -39,6 +39,25 @@ A spot light lights an object like this:
 
 ![Spot light](/img/user-manual/graphics/lighting/lights/spot.jpg)
 
+## Light Direction {#light-direction}
+
+Directional and spot lights are aimed by rotating their entity: both shine along the entity's **negative Y axis**, so an unrotated light shines straight down. Omni lights emit in all directions, so their rotation has no effect.
+
+```javascript
+// an unrotated light shines straight down
+light.setEulerAngles(0, 0, 0);
+
+// tilted 45 degrees, it shines down and towards negative z
+light.setEulerAngles(45, 0, 0);
+```
+
+Note that [`lookAt`](https://api.playcanvas.com/engine/classes/GraphNode.html#lookat) orients an entity's negative Z axis. That aims a camera, but not a light — follow it with a quarter turn to bring the negative Y axis onto the target:
+
+```javascript
+light.lookAt(target.getPosition());
+light.rotateLocal(90, 0, 0);
+```
+
 ## Light Shapes {#light-shapes}
 
 There are four light source shapes:

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/lighting/lights.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/lighting/lights.md
@@ -39,6 +39,25 @@ PlayCanvasには3つの種類の光源があります。
 
 ![Spot light](/img/user-manual/graphics/lighting/lights/spot.jpg)
 
+## Light Direction {#light-direction}
+
+ディレクショナルライトとスポットライトは、エンティティを回転させることで向きを決めます。どちらもエンティティの**負のY軸**の方向に光を発するため、回転していないライトは真下を照らします。オムニライトはすべての方向に光を発するため、回転は影響しません。
+
+```javascript
+// 回転していないライトは真下を照らします
+light.setEulerAngles(0, 0, 0);
+
+// 45度傾けると、下方向かつ負のz方向を照らします
+light.setEulerAngles(45, 0, 0);
+```
+
+なお、[`lookAt`](https://api.playcanvas.com/engine/classes/GraphNode.html#lookat)はエンティティの負のZ軸を向けます。これはカメラの向きを合わせるには適していますが、ライトには適していません。負のY軸を対象に向けるには、続けて90度回転させてください。
+
+```javascript
+light.lookAt(target.getPosition());
+light.rotateLocal(90, 0, 0);
+```
+
 ## Light Shapes {#light-shapes}
 
 光源の形状には4つのタイプがあります。


### PR DESCRIPTION
The lights page explained the three light types but never said which way a light actually
points, which is a common source of confusion - particularly that `lookAt` does not aim a light
the way it aims a camera.

**Changes:**
- New `Light Direction` section on the lights page, stating that directional and spot lights
  emit along their entity's negative Y axis, so an unrotated light shines straight down, and
  that omni rotation has no effect.
- Notes that `lookAt` orients the negative Z axis, so aiming a light at a target needs a
  following quarter turn, with a snippet showing it.
- Japanese translation updated to match.