### PR TITLE
docs: track Web Components 0.18.0 — shadow cascades and engine-aligned defaults

### DIFF
--- a/docs/user-manual/web-components/tags/pc-anim-clip.md
+++ b/docs/user-manual/web-components/tags/pc-anim-clip.md
@@ -19,14 +19,12 @@ The `<pc-anim-clip>` tag declares one named animation clip on a [`<pc-anim>`](..
 **The enclosing model.** With no `asset`, the track comes from the container of the [`<pc-model>`](../pc-model) that encloses the parent [`<pc-anim>`](../pc-anim). This is the usual case — a GLB exported with several animations, each declared as a clip:
 
 ```html
-<pc-entity name="hero">
-    <pc-model asset="hero-glb">
-        <pc-anim>
-            <pc-anim-clip name="idle"></pc-anim-clip>
-            <pc-anim-clip name="run"></pc-anim-clip>
-        </pc-anim>
-    </pc-model>
-</pc-entity>
+<pc-model name="hero" asset="hero-glb">
+    <pc-anim>
+        <pc-anim-clip name="idle"></pc-anim-clip>
+        <pc-anim-clip name="run"></pc-anim-clip>
+    </pc-anim>
+</pc-model>
 ```
 
 **A named asset.** Point `asset` at a [`<pc-asset>`](../pc-asset) to take the track from a separate file, which is how a shared clip library gets applied to a model that was exported without it. Three asset types work: a `container` (a GLB), an `animation` GLB, or an `animclip` JSON.
@@ -35,14 +33,12 @@ The `<pc-anim-clip>` tag declares one named animation clip on a [`<pc-anim>`](..
 <pc-asset id="hero-glb" type="container" src="hero.glb"></pc-asset>
 <pc-asset id="wave" type="container" src="clips/wave.glb"></pc-asset>
 
-<pc-entity name="hero">
-    <pc-model asset="hero-glb">
-        <pc-anim>
-            <pc-anim-clip name="idle"></pc-anim-clip>
-            <pc-anim-clip name="wave" asset="wave"></pc-anim-clip>
-        </pc-anim>
-    </pc-model>
-</pc-entity>
+<pc-model name="hero" asset="hero-glb">
+    <pc-anim>
+        <pc-anim-clip name="idle"></pc-anim-clip>
+        <pc-anim-clip name="wave" asset="wave"></pc-anim-clip>
+    </pc-anim>
+</pc-model>
 ```
 
 Mixing the two is fine, as the snippet above does: clips without an `asset` come from the model, and the ones with it come from their own file.
@@ -92,7 +88,7 @@ The same walk cycle declared as two clips, `walk` and a reversed, slowed `sneak`
             </pc-script>
         </pc-entity>
         <pc-entity name="light" rotation="45 30 0">
-            <pc-light cast-shadows shadow-distance="20" intensity="1.5"></pc-light>
+            <pc-light cast-shadows normal-offset-bias="0.05" shadow-bias="0.2" shadow-distance="20" intensity="1.5"></pc-light>
         </pc-entity>
         <pc-entity name="ground" scale="30 30 30">
             <pc-render type="plane" material="floor"></pc-render>

--- a/docs/user-manual/web-components/tags/pc-anim.md
+++ b/docs/user-manual/web-components/tags/pc-anim.md
@@ -118,7 +118,7 @@ A GLB with a single walk cycle, declared twice: `walk` at its authored speed and
             </pc-script>
         </pc-entity>
         <pc-entity name="light" rotation="45 30 0">
-            <pc-light cast-shadows shadow-distance="20" intensity="1.5"></pc-light>
+            <pc-light cast-shadows normal-offset-bias="0.05" shadow-bias="0.2" shadow-distance="20" intensity="1.5"></pc-light>
         </pc-entity>
         <pc-entity name="ground" scale="30 30 30">
             <pc-render type="plane" material="floor"></pc-render>

--- a/docs/user-manual/web-components/tags/pc-audio-listener.md
+++ b/docs/user-manual/web-components/tags/pc-audio-listener.md
@@ -36,7 +36,7 @@ The listener sits on the camera, and a sphere emitting positional footsteps circ
             <pc-audio-listener></pc-audio-listener>
         </pc-entity>
         <pc-entity name="light" rotation="45 30 0">
-            <pc-light cast-shadows></pc-light>
+            <pc-light cast-shadows normal-offset-bias="0.05" shadow-bias="0.2"></pc-light>
         </pc-entity>
         <pc-entity name="ground" scale="14 14 14">
             <pc-render type="plane" material="floor"></pc-render>

--- a/docs/user-manual/web-components/tags/pc-camera.md
+++ b/docs/user-manual/web-components/tags/pc-camera.md
@@ -19,8 +19,9 @@ The `<pc-camera>` tag is used to define a camera component.
 | --- | --- | --- | --- |
 | `clear-color` | Color | `"0.75 0.75 0.75 1"` | Background color as space-separated RGBA values, hex code, or [named color](https://github.com/playcanvas/web-components/blob/main/src/colors.ts) |
 | `clear-color-buffer` | Boolean | `"true"` | Controls whether the camera clears the color buffer |
+| `clear-depth` | Number | `"1"` | The depth value the depth buffer is cleared to |
 | `clear-depth-buffer` | Boolean | `"true"` | Controls whether the camera clears the depth buffer |
-| `clear-stencil-buffer` | Boolean | `"false"` | Controls whether the camera clears the stencil buffer |
+| `clear-stencil-buffer` | Boolean | `"true"` | Controls whether the camera clears the stencil buffer |
 | `cull-faces` | Boolean | `"true"` | Controls whether the camera culls faces |
 | `enabled` | Boolean | `"true"` | Enabled state of the component |
 | `far-clip` | Number | `"1000"` | The far clipping plane distance |

--- a/docs/user-manual/web-components/tags/pc-collision.md
+++ b/docs/user-manual/web-components/tags/pc-collision.md
@@ -58,7 +58,7 @@ Each collision shape matches its rendered shape: a sphere, a capsule and a box t
             <pc-camera clear-color="#1d1f2b"></pc-camera>
         </pc-entity>
         <pc-entity name="light" rotation="45 30 0">
-            <pc-light cast-shadows></pc-light>
+            <pc-light cast-shadows normal-offset-bias="0.05" shadow-bias="0.2"></pc-light>
         </pc-entity>
         <pc-entity name="ball" position="-1.5 4 0">
             <pc-render type="sphere"></pc-render>

--- a/docs/user-manual/web-components/tags/pc-gsplat.md
+++ b/docs/user-manual/web-components/tags/pc-gsplat.md
@@ -54,3 +54,5 @@ A Gaussian splat scanned from a real toy. Drag to orbit and scroll to zoom — a
 ## JavaScript Interface
 
 You can programmatically create and manipulate `<pc-gsplat>` elements using the [GSplatComponentElement API](https://api.playcanvas.com/web-components/classes/GSplatComponentElement.html).
+
+The examples cover a few splat workflows: [Basic Splat](https://playcanvas.github.io/web-components/examples/basic-splat.html), [Splat Annotations](https://playcanvas.github.io/web-components/examples/splat-annotations.html), [Splat Flipbook](https://playcanvas.github.io/web-components/examples/splat-flipbook.html) and [Splat Streaming](https://playcanvas.github.io/web-components/examples/splat-streaming.html).

--- a/docs/user-manual/web-components/tags/pc-light.md
+++ b/docs/user-manual/web-components/tags/pc-light.md
@@ -17,28 +17,60 @@ The `<pc-light>` tag is used to define a light component.
 
 | Attribute | Type | Default | Description |
 | --- | --- | --- | --- |
+| `cascade-blend` | Number | `"0"` | Fraction of each shadow cascade blended into the next, from 0 (no blending) to 1. Used by `directional` lights with `num-cascades` above 1 |
+| `cascade-distribution` | Number | `"0.5"` | How the camera frustum is split between cascades, from 0 (linear) to 1 (logarithmic, concentrating resolution near the camera). Used by `directional` lights with `num-cascades` above 1 |
 | `cast-shadows` | Boolean | `"false"` | Whether the light casts shadows |
 | `color` | Color | `"1 1 1"` | Light color as space-separated RGB values, hex code, or [named color](https://github.com/playcanvas/web-components/blob/main/src/colors.ts) |
 | `enabled` | Boolean | `"true"` | Enabled state of the component |
 | `inner-cone-angle` | Number | `"40"` | Inner cone angle in degrees (for spot lights) |
 | `intensity` | Number | `"1"` | Light intensity multiplier |
-| `normal-offset-bias` | Number | `"0.05"` | Normal offset bias for shadow rendering |
+| `normal-offset-bias` | Number | `"0"` | Normal offset bias for shadow rendering |
+| `num-cascades` | Number | `"1"` | Number of shadow cascades, an integer from 1 (no cascades) to 4. Used by `directional` lights |
 | `outer-cone-angle` | Number | `"45"` | Outer cone angle in degrees (for spot lights) |
 | `penumbra-falloff` | Number | `"1"` | PCSS shadow penumbra falloff rate |
 | `penumbra-size` | Number | `"1"` | PCSS shadow penumbra size |
 | `range` | Number | `"10"` | Light range distance |
-| `shadow-bias` | Number | `"0.2"` | Shadow depth bias |
+| `shadow-bias` | Number | `"0.05"` | Shadow depth bias |
 | `shadow-blocker-samples` | Number | `"16"` | Number of PCSS shadow blocker samples |
-| `shadow-distance` | Number | `"16"` | Maximum shadow rendering distance |
+| `shadow-distance` | Number | `"40"` | Maximum shadow rendering distance |
 | `shadow-intensity` | Number | `"1"` | Shadow intensity multiplier |
 | `shadow-resolution` | Number | `"1024"` | Shadow map resolution |
 | `shadow-samples` | Number | `"16"` | Number of PCSS shadow samples |
 | `shadow-type` | Enum | `"pcf3-32f"` | Shadow filtering: `"pcf1-16f"` \| `"pcf1-32f"` \| `"pcf3-16f"` \| `"pcf3-32f"` \| `"pcf5-16f"` \| `"pcf5-32f"` \| `"vsm-16f"` \| `"vsm-32f"` \| `"pcss-32f"` |
 | `type` | Enum | `"directional"` | Light type: `"directional"` \| `"omni"` \| `"spot"` |
-| `vsm-bias` | Number | `"0.01"` | Variance shadow map bias |
+| `vsm-bias` | Number | `"0.0025"` | Variance shadow map bias |
 | `vsm-blur-size` | Number | `"11"` | Variance shadow map blur size (1-25) |
 
 </div>
+
+Every default here is the engine's own, so a `<pc-light>` with an attribute absent renders exactly as a light the engine built for itself. That matters most for the shadow-tuning attributes: they are deliberately left untuned rather than pre-set to values that flatter a small scene, so expect to reach for `shadow-bias` and `normal-offset-bias` yourself once shadows are on and something looks wrong.
+
+## Shadow Cascades
+
+A single shadow map stretched over a long view runs out of resolution — shadows near the camera go blocky while distant ones stay coarse. Cascades split the camera frustum into slices and give each its own shadow map, so detail follows the camera. They apply to `directional` lights only, and they are off until you ask for them:
+
+```html
+<pc-entity name="sun" rotation="45 30 0">
+    <pc-light cast-shadows
+              num-cascades="4"
+              cascade-distribution="0.7"
+              cascade-blend="0.1"
+              shadow-distance="200"
+              shadow-resolution="2048"></pc-light>
+</pc-entity>
+```
+
+The three attributes do distinct jobs, and only `num-cascades` above 1 brings the other two into play:
+
+| Attribute | What it controls |
+| --- | --- |
+| `num-cascades` | How many slices, 1 to 4. More slices means more detail per slice, at the cost of a shadow render pass each |
+| `cascade-distribution` | Where the splits fall between 0 (evenly spaced) and 1 (packed towards the camera). Raise it when near shadows need the detail; lower it when the far slice looks starved |
+| `cascade-blend` | How much of each slice cross-fades into the next, 0 to 1. A small value hides the seams where slices meet; too much wastes resolution on the overlap |
+
+`shadow-distance` still bounds the whole thing — it is the range the cascades divide up, so raising the cascade count without raising the distance just subdivides the same near-field. `shadow-resolution` is per cascade, not a shared budget.
+
+The [Shadow Cascades example](https://playcanvas.github.io/web-components/examples/shadow-cascades.html) drives all three over a desert causeway long enough to need them, and plots the split distances the renderer derives — worth a look, because the engine has no cascade debug view and the distribution slider otherwise appears to do nothing.
 
 ## Example
 
@@ -52,7 +84,7 @@ Try editing the light `color`, `intensity` or `type` values and watch the scene 
         </pc-entity>
         <!-- A warm spot light shining down (spot lights point down the negative Y axis) -->
         <pc-entity name="spot-light" position="-2 4 0">
-            <pc-light type="spot" color="#ffb47a" intensity="5" outer-cone-angle="35" cast-shadows></pc-light>
+            <pc-light type="spot" color="#ffb47a" intensity="5" outer-cone-angle="35" cast-shadows normal-offset-bias="0.05" shadow-bias="0.2"></pc-light>
         </pc-entity>
         <!-- A cool omni light between the shapes -->
         <pc-entity name="omni-light" position="2 2 1">

--- a/docs/user-manual/web-components/tags/pc-material.md
+++ b/docs/user-manual/web-components/tags/pc-material.md
@@ -114,7 +114,7 @@ Four materials: a plain color, a metal, a transparent "glass" and a tiled textur
             <pc-camera clear-color="#1d1f2b" tonemap="aces"></pc-camera>
         </pc-entity>
         <pc-entity name="light" rotation="45 30 0">
-            <pc-light cast-shadows intensity="1.5"></pc-light>
+            <pc-light cast-shadows normal-offset-bias="0.05" shadow-bias="0.2" intensity="1.5"></pc-light>
         </pc-entity>
         <pc-entity name="box" position="-2 0.5 0">
             <pc-render type="box" material="crimson"></pc-render>

--- a/docs/user-manual/web-components/tags/pc-model.md
+++ b/docs/user-manual/web-components/tags/pc-model.md
@@ -113,7 +113,7 @@ A GLB with a skeletal animation, played by the [`<pc-anim>`](../pc-anim) nested 
             </pc-script>
         </pc-entity>
         <pc-entity name="light" rotation="45 30 0">
-            <pc-light cast-shadows shadow-distance="20" intensity="1.5"></pc-light>
+            <pc-light cast-shadows normal-offset-bias="0.05" shadow-bias="0.2" shadow-distance="20" intensity="1.5"></pc-light>
         </pc-entity>
         <pc-entity name="ground" scale="30 30 30">
             <pc-render type="plane" material="floor"></pc-render>

--- a/docs/user-manual/web-components/tags/pc-render.md
+++ b/docs/user-manual/web-components/tags/pc-render.md
@@ -42,7 +42,7 @@ All six primitive shapes. Try changing any `type`, or add `material` once you ha
             <pc-camera clear-color="#2a2d36"></pc-camera>
         </pc-entity>
         <pc-entity name="light" rotation="45 30 0">
-            <pc-light cast-shadows intensity="1.5"></pc-light>
+            <pc-light cast-shadows normal-offset-bias="0.05" shadow-bias="0.2" intensity="1.5"></pc-light>
         </pc-entity>
         <pc-entity name="box" position="-2.5 0.5 0">
             <pc-render type="box"></pc-render>

--- a/docs/user-manual/web-components/tags/pc-rigid-body.md
+++ b/docs/user-manual/web-components/tags/pc-rigid-body.md
@@ -44,7 +44,7 @@ Dynamic bodies falling onto a static ground. The sphere has `restitution="0.9"`,
             <pc-camera clear-color="#1d1f2b"></pc-camera>
         </pc-entity>
         <pc-entity name="light" rotation="45 30 0">
-            <pc-light cast-shadows></pc-light>
+            <pc-light cast-shadows normal-offset-bias="0.05" shadow-bias="0.2"></pc-light>
         </pc-entity>
         <pc-entity name="box-1" position="-1.5 4 0" rotation="30 10 40">
             <pc-render type="box"></pc-render>

--- a/docs/user-manual/web-components/tags/pc-wasm.md
+++ b/docs/user-manual/web-components/tags/pc-wasm.md
@@ -63,7 +63,7 @@ Loading the `Ammo` physics module. The box only falls because the module is decl
             <pc-camera clear-color="#1d1f2b"></pc-camera>
         </pc-entity>
         <pc-entity name="light" rotation="45 30 0">
-            <pc-light cast-shadows></pc-light>
+            <pc-light cast-shadows normal-offset-bias="0.05" shadow-bias="0.2"></pc-light>
         </pc-entity>
         <pc-entity name="crate" position="0 4 0" rotation="25 15 35">
             <pc-render type="box"></pc-render>

--- a/docs/user-manual/web-components/xr.md
+++ b/docs/user-manual/web-components/xr.md
@@ -131,7 +131,7 @@ import { whenReady } from '@playcanvas/web-components';
 
 const camera = await whenReady('pc-camera');
 
-if (camera.xrAvailable) {
+if (camera.vrAvailable) {
     camera.startXr('immersive-vr', 'local-floor');
 }
 
@@ -139,7 +139,16 @@ if (camera.xrAvailable) {
 camera.endXr();
 ```
 
-`startXr(type, space)` takes the session type (`'immersive-ar'` or `'immersive-vr'`) and a reference space (`'viewer'`, `'local'`, `'local-floor'`, `'bounded-floor'` or `'unbounded'`). The `xrAvailable` getter reports whether an immersive session can be started; `startXr` does nothing while it is `false`. Note that the `xrSession` script also manages the camera rig transforms, AR transparency and session cleanup for you — prefer it for full experiences, and the element API for quick tests and simple viewers.
+`startXr(type, space)` takes the session type (`'immersive-ar'` or `'immersive-vr'`) and a reference space (`'viewer'`, `'local'`, `'local-floor'`, `'bounded-floor'` or `'unbounded'`).
+
+Availability is reported per mode, by `arAvailable` and `vrAvailable`. The two are independent — a device can offer either without the other, and an Android phone with ARCore commonly offers AR and no VR — so gate each control on the mode it starts:
+
+```javascript
+document.getElementById('enter-vr').hidden = !camera.vrAvailable;
+document.getElementById('enter-ar').hidden = !camera.arAvailable;
+```
+
+`startXr` is gated the same way and does nothing when the mode being asked for is unavailable, so a button that slips through does not fail loudly. Note that the `xrSession` script also manages the camera rig transforms, AR transparency and session cleanup for you — prefer it for full experiences, and the element API for quick tests and simple viewers.
 
 Most of the [Web Component examples](https://playcanvas.github.io/web-components/examples/) have integrated support for XR. Consult their source code to see how it's done.
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-anim-clip.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-anim-clip.md
@@ -19,14 +19,12 @@ description: "pc-anim-clip要素のリファレンス: pc-animコンポーネン
 **囲んでいるモデル。** `asset`がない場合、トラックは親の[`<pc-anim>`](../pc-anim)を囲む[`<pc-model>`](../pc-model)のコンテナから取得されます。これが通常のケースです。複数のアニメーションを含めてエクスポートされたGLBの各アニメーションを、クリップとして宣言します。
 
 ```html
-<pc-entity name="hero">
-    <pc-model asset="hero-glb">
-        <pc-anim>
-            <pc-anim-clip name="idle"></pc-anim-clip>
-            <pc-anim-clip name="run"></pc-anim-clip>
-        </pc-anim>
-    </pc-model>
-</pc-entity>
+<pc-model name="hero" asset="hero-glb">
+    <pc-anim>
+        <pc-anim-clip name="idle"></pc-anim-clip>
+        <pc-anim-clip name="run"></pc-anim-clip>
+    </pc-anim>
+</pc-model>
 ```
 
 **名前を指定したアセット。** `asset`で[`<pc-asset>`](../pc-asset)を指すと、トラックを別のファイルから取得できます。共有のクリップライブラリを、それを含めずにエクスポートされたモデルに適用する方法です。使用できるアセットタイプは3つです。`container`（GLB）、`animation`のGLB、`animclip`のJSONです。
@@ -35,14 +33,12 @@ description: "pc-anim-clip要素のリファレンス: pc-animコンポーネン
 <pc-asset id="hero-glb" type="container" src="hero.glb"></pc-asset>
 <pc-asset id="wave" type="container" src="clips/wave.glb"></pc-asset>
 
-<pc-entity name="hero">
-    <pc-model asset="hero-glb">
-        <pc-anim>
-            <pc-anim-clip name="idle"></pc-anim-clip>
-            <pc-anim-clip name="wave" asset="wave"></pc-anim-clip>
-        </pc-anim>
-    </pc-model>
-</pc-entity>
+<pc-model name="hero" asset="hero-glb">
+    <pc-anim>
+        <pc-anim-clip name="idle"></pc-anim-clip>
+        <pc-anim-clip name="wave" asset="wave"></pc-anim-clip>
+    </pc-anim>
+</pc-model>
 ```
 
 上のスニペットのように、2つを混在させても問題ありません。`asset`のないクリップはモデルから、`asset`のあるクリップはそれぞれのファイルから取得されます。
@@ -92,7 +88,7 @@ description: "pc-anim-clip要素のリファレンス: pc-animコンポーネン
             </pc-script>
         </pc-entity>
         <pc-entity name="light" rotation="45 30 0">
-            <pc-light cast-shadows shadow-distance="20" intensity="1.5"></pc-light>
+            <pc-light cast-shadows normal-offset-bias="0.05" shadow-bias="0.2" shadow-distance="20" intensity="1.5"></pc-light>
         </pc-entity>
         <pc-entity name="ground" scale="30 30 30">
             <pc-render type="plane" material="floor"></pc-render>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-anim.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-anim.md
@@ -118,7 +118,7 @@ const done = baseLayer.activeStateCurrentTime >= baseLayer.activeStateDuration;
             </pc-script>
         </pc-entity>
         <pc-entity name="light" rotation="45 30 0">
-            <pc-light cast-shadows shadow-distance="20" intensity="1.5"></pc-light>
+            <pc-light cast-shadows normal-offset-bias="0.05" shadow-bias="0.2" shadow-distance="20" intensity="1.5"></pc-light>
         </pc-entity>
         <pc-entity name="ground" scale="30 30 30">
             <pc-render type="plane" material="floor"></pc-render>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-audio-listener.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-audio-listener.md
@@ -36,7 +36,7 @@ description: "pc-audio-listener要素のリファレンス: 位置サウンド�
             <pc-audio-listener></pc-audio-listener>
         </pc-entity>
         <pc-entity name="light" rotation="45 30 0">
-            <pc-light cast-shadows></pc-light>
+            <pc-light cast-shadows normal-offset-bias="0.05" shadow-bias="0.2"></pc-light>
         </pc-entity>
         <pc-entity name="ground" scale="14 14 14">
             <pc-render type="plane" material="floor"></pc-render>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-camera.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-camera.md
@@ -19,8 +19,9 @@ description: "pc-camera要素のリファレンス: エンジンのカメラComp
 | --- | --- | --- | --- |
 | `clear-color` | Color | `"0.75 0.75 0.75 1"` | スペース区切りのRGBA値、16進数コード、または[名前付きカラー](https://github.com/playcanvas/web-components/blob/main/src/colors.ts)としての背景色 |
 | `clear-color-buffer` | Boolean | `"true"` | カメラがカラーバッファをクリアするかどうかを制御します |
+| `clear-depth` | Number | `"1"` | デプスバッファをクリアする際の深度値 |
 | `clear-depth-buffer` | Boolean | `"true"` | カメラがデプスバッファをクリアするかどうかを制御します |
-| `clear-stencil-buffer` | Boolean | `"false"` | カメラがステンシルバッファをクリアするかどうかを制御します |
+| `clear-stencil-buffer` | Boolean | `"true"` | カメラがステンシルバッファをクリアするかどうかを制御します |
 | `cull-faces` | Boolean | `"true"` | カメラが面をカリングするかどうかを制御します |
 | `enabled` | Boolean | `"true"` | コンポーネントの有効状態 |
 | `far-clip` | Number | `"1000"` | ファーカリングプレーンの距離 |

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-collision.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-collision.md
@@ -58,7 +58,7 @@ description: "pc-collision要素のリファレンス: rigid bodyと組み合わ
             <pc-camera clear-color="#1d1f2b"></pc-camera>
         </pc-entity>
         <pc-entity name="light" rotation="45 30 0">
-            <pc-light cast-shadows></pc-light>
+            <pc-light cast-shadows normal-offset-bias="0.05" shadow-bias="0.2"></pc-light>
         </pc-entity>
         <pc-entity name="ball" position="-1.5 4 0">
             <pc-render type="sphere"></pc-render>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-gsplat.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-gsplat.md
@@ -54,3 +54,5 @@ description: "pc-gsplat要素のリファレンス: Gaussian splat Assetをレ�
 ## JavaScriptインターフェース {#javascript-interface}
 
 [GSplatComponentElement API](https://api.playcanvas.com/web-components/classes/GSplatComponentElement.html)を使用して、`<pc-gsplat>`要素をプログラムで作成および操作できます。
+
+スプラットのワークフローはサンプルでいくつか扱っています。[Basic Splat](https://playcanvas.github.io/web-components/examples/basic-splat.html)、[Splat Annotations](https://playcanvas.github.io/web-components/examples/splat-annotations.html)、[Splat Flipbook](https://playcanvas.github.io/web-components/examples/splat-flipbook.html)、[Splat Streaming](https://playcanvas.github.io/web-components/examples/splat-streaming.html)です。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-light.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-light.md
@@ -17,28 +17,60 @@ description: "pc-light要素のリファレンス: ライトの種類、色、�
 
 | 属性 | タイプ | デフォルト | 説明 |
 | --- | --- | --- | --- |
+| `cascade-blend` | Number | `"0"` | 各シャドウカスケードを次のカスケードへブレンドする割合。0（ブレンドなし）から1。`num-cascades`が1より大きい`directional`ライトで使用されます |
+| `cascade-distribution` | Number | `"0.5"` | カメラの視錐台をカスケード間で分割する方法。0（等間隔）から1（対数的で、カメラ近傍に解像度を集中）。`num-cascades`が1より大きい`directional`ライトで使用されます |
 | `cast-shadows` | Boolean | `"false"` | ライトが影を落とすかどうか |
 | `color` | Color | `"1 1 1"` | スペース区切りのRGB値、16進数コード、または[名前付き色](https://github.com/playcanvas/web-components/blob/main/src/colors.ts)としてのライトの色 |
 | `enabled` | Boolean | `"true"` | コンポーネントの有効状態 |
 | `inner-cone-angle` | Number | `"40"` | 内側コーン角度（度単位、スポットライト用） |
 | `intensity` | Number | `"1"` | ライトの強度乗数 |
-| `normal-offset-bias` | Number | `"0.05"` | シャドウレンダリング用の法線オフセットバイアス |
+| `normal-offset-bias` | Number | `"0"` | シャドウレンダリング用の法線オフセットバイアス |
+| `num-cascades` | Number | `"1"` | シャドウカスケードの数。1（カスケードなし）から4の整数。`directional`ライトで使用されます |
 | `outer-cone-angle` | Number | `"45"` | 外側コーン角度（度単位、スポットライト用） |
 | `penumbra-falloff` | Number | `"1"` | PCSSシャドウの半影減衰率 |
 | `penumbra-size` | Number | `"1"` | PCSSシャドウの半影サイズ |
 | `range` | Number | `"10"` | ライトの有効距離 |
-| `shadow-bias` | Number | `"0.2"` | 影の深度バイアス |
+| `shadow-bias` | Number | `"0.05"` | 影の深度バイアス |
 | `shadow-blocker-samples` | Number | `"16"` | PCSSシャドウブロッカーのサンプル数 |
-| `shadow-distance` | Number | `"16"` | シャドウレンダリングの最大距離 |
+| `shadow-distance` | Number | `"40"` | シャドウレンダリングの最大距離 |
 | `shadow-intensity` | Number | `"1"` | 影の強度乗数 |
 | `shadow-resolution` | Number | `"1024"` | シャドウマップの解像度 |
 | `shadow-samples` | Number | `"16"` | PCSSシャドウのサンプル数 |
 | `shadow-type` | Enum | `"pcf3-32f"` | 影のフィルタリング: `"pcf1-16f"` \| `"pcf1-32f"` \| `"pcf3-16f"` \| `"pcf3-32f"` \| `"pcf5-16f"` \| `"pcf5-32f"` \| `"vsm-16f"` \| `"vsm-32f"` \| `"pcss-32f"` |
 | `type` | Enum | `"directional"` | ライトのタイプ: `"directional"` \| `"omni"` \| `"spot"` |
-| `vsm-bias` | Number | `"0.01"` | バリアンスシャドウマップのバイアス |
+| `vsm-bias` | Number | `"0.0025"` | バリアンスシャドウマップのバイアス |
 | `vsm-blur-size` | Number | `"11"` | バリアンスシャドウマップのぼかしサイズ（1〜25） |
 
 </div>
+
+ここでのデフォルト値はすべてエンジン自身のものです。そのため、属性を省略した`<pc-light>`は、エンジンが自ら構築したライトとまったく同じようにレンダリングされます。これが特に重要なのはシャドウ調整用の属性です。小さなシーンで見栄えよく見せる値をあらかじめ設定するのではなく、意図的に未調整のままにしてあります。影を有効にして何かがおかしいと感じたら、`shadow-bias`や`normal-offset-bias`は自分で調整することになります。
+
+## シャドウカスケード {#shadow-cascades}
+
+1枚のシャドウマップを遠くまでの視界に引き伸ばすと解像度が足りなくなります。カメラ近くの影はブロック状になり、遠くの影は粗いままです。カスケードはカメラの視錐台をいくつかのスライスに分割し、それぞれに専用のシャドウマップを与えるため、ディテールがカメラに追従します。これは`directional`ライトにのみ適用され、明示的に指定するまで無効です。
+
+```html
+<pc-entity name="sun" rotation="45 30 0">
+    <pc-light cast-shadows
+              num-cascades="4"
+              cascade-distribution="0.7"
+              cascade-blend="0.1"
+              shadow-distance="200"
+              shadow-resolution="2048"></pc-light>
+</pc-entity>
+```
+
+3つの属性はそれぞれ異なる役割を持ち、`num-cascades`が1より大きい場合にのみ他の2つが効いてきます。
+
+| 属性 | 制御する内容 |
+| --- | --- |
+| `num-cascades` | スライスの数（1〜4）。多いほどスライスごとのディテールは増えますが、その分シャドウの描画パスが増えます |
+| `cascade-distribution` | 分割位置。0（等間隔）から1（カメラ寄りに密集）。手前の影にディテールが必要なら上げ、遠方のスライスが不足して見えるなら下げます |
+| `cascade-blend` | 各スライスを次のスライスへクロスフェードさせる量（0〜1）。小さな値でスライスの継ぎ目を隠せますが、大きすぎると重なり部分に解像度を無駄に使います |
+
+全体の範囲は依然として`shadow-distance`が決めます。これがカスケードで分割される距離なので、距離を上げずにカスケード数だけ増やしても、同じ近距離範囲をさらに細分するだけです。`shadow-resolution`は共有の予算ではなく、カスケードごとの値です。
+
+[Shadow Cascadesのサンプル](https://playcanvas.github.io/web-components/examples/shadow-cascades.html)は、カスケードが必要になるほど長い砂漠の堤道で3つの属性すべてを操作でき、レンダラーが導出する分割距離もプロットします。エンジンにはカスケードのデバッグビューがなく、それがないと`cascade-distribution`のスライダーは何も効いていないように見えるため、一見の価値があります。
 
 ## 例 {#example}
 
@@ -52,7 +84,7 @@ description: "pc-light要素のリファレンス: ライトの種類、色、�
         </pc-entity>
         <!-- 下向きに照らす暖色のスポットライト (スポットライトはY軸負方向を向きます) -->
         <pc-entity name="spot-light" position="-2 4 0">
-            <pc-light type="spot" color="#ffb47a" intensity="5" outer-cone-angle="35" cast-shadows></pc-light>
+            <pc-light type="spot" color="#ffb47a" intensity="5" outer-cone-angle="35" cast-shadows normal-offset-bias="0.05" shadow-bias="0.2"></pc-light>
         </pc-entity>
         <!-- 形状の間に置いた寒色のオムニライト -->
         <pc-entity name="omni-light" position="2 2 1">

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-material.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-material.md
@@ -114,7 +114,7 @@ description: "pc-material要素のリファレンス: カラー、メタルネ�
             <pc-camera clear-color="#1d1f2b" tonemap="aces"></pc-camera>
         </pc-entity>
         <pc-entity name="light" rotation="45 30 0">
-            <pc-light cast-shadows intensity="1.5"></pc-light>
+            <pc-light cast-shadows normal-offset-bias="0.05" shadow-bias="0.2" intensity="1.5"></pc-light>
         </pc-entity>
         <pc-entity name="box" position="-2 0.5 0">
             <pc-render type="box" material="crimson"></pc-render>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-model.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-model.md
@@ -113,7 +113,7 @@ console.log(anim.clips); // ['Walk', 'Idle']
             </pc-script>
         </pc-entity>
         <pc-entity name="light" rotation="45 30 0">
-            <pc-light cast-shadows shadow-distance="20" intensity="1.5"></pc-light>
+            <pc-light cast-shadows normal-offset-bias="0.05" shadow-bias="0.2" shadow-distance="20" intensity="1.5"></pc-light>
         </pc-entity>
         <pc-entity name="ground" scale="30 30 30">
             <pc-render type="plane" material="floor"></pc-render>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-render.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-render.md
@@ -42,7 +42,7 @@ glTF/GLBファイルから3Dモデルをレンダリングするには、代わ�
             <pc-camera clear-color="#2a2d36"></pc-camera>
         </pc-entity>
         <pc-entity name="light" rotation="45 30 0">
-            <pc-light cast-shadows intensity="1.5"></pc-light>
+            <pc-light cast-shadows normal-offset-bias="0.05" shadow-bias="0.2" intensity="1.5"></pc-light>
         </pc-entity>
         <pc-entity name="box" position="-2.5 0.5 0">
             <pc-render type="box"></pc-render>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-rigid-body.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-rigid-body.md
@@ -44,7 +44,7 @@ description: "pc-rigid-body要素のリファレンス: rigid bodyの種類、�
             <pc-camera clear-color="#1d1f2b"></pc-camera>
         </pc-entity>
         <pc-entity name="light" rotation="45 30 0">
-            <pc-light cast-shadows></pc-light>
+            <pc-light cast-shadows normal-offset-bias="0.05" shadow-bias="0.2"></pc-light>
         </pc-entity>
         <pc-entity name="box-1" position="-1.5 4 0" rotation="30 10 40">
             <pc-render type="box"></pc-render>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-wasm.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-wasm.md
@@ -53,7 +53,7 @@ description: "pc-wasm要素のリファレンス: glue・wasm・fallbackのパ�
             <pc-camera clear-color="#1d1f2b"></pc-camera>
         </pc-entity>
         <pc-entity name="light" rotation="45 30 0">
-            <pc-light cast-shadows></pc-light>
+            <pc-light cast-shadows normal-offset-bias="0.05" shadow-bias="0.2"></pc-light>
         </pc-entity>
         <pc-entity name="crate" position="0 4 0" rotation="25 15 35">
             <pc-render type="box"></pc-render>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/xr.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/xr.md
@@ -131,7 +131,7 @@ import { whenReady } from '@playcanvas/web-components';
 
 const camera = await whenReady('pc-camera');
 
-if (camera.xrAvailable) {
+if (camera.vrAvailable) {
     camera.startXr('immersive-vr', 'local-floor');
 }
 
@@ -139,7 +139,16 @@ if (camera.xrAvailable) {
 camera.endXr();
 ```
 
-`startXr(type, space)` は、セッションタイプ（`'immersive-ar'` または `'immersive-vr'`）と参照空間（`'viewer'`、`'local'`、`'local-floor'`、`'bounded-floor'`、`'unbounded'`）を受け取ります。`xrAvailable` ゲッターは、イマーシブセッションを開始できるかどうかを返します。`false` の間、`startXr` は何もしません。なお、`xrSession` スクリプトはカメラリグのトランスフォーム、ARの透過、セッションのクリーンアップも管理してくれるため、本格的な体験にはスクリプトを、簡単なテストやシンプルなビューアーには要素APIを使うのがおすすめです。
+`startXr(type, space)` は、セッションタイプ（`'immersive-ar'` または `'immersive-vr'`）と参照空間（`'viewer'`、`'local'`、`'local-floor'`、`'bounded-floor'`、`'unbounded'`）を受け取ります。
+
+利用可否はモード単位で、`arAvailable` と `vrAvailable` が報告します。この2つは互いに独立しています。デバイスは一方だけを提供できますし、ARCore対応のAndroid端末はARのみを提供しVRを提供しないことがよくあります。そのため、各コントロールはそれが開始するモードで判定してください。
+
+```javascript
+document.getElementById('enter-vr').hidden = !camera.vrAvailable;
+document.getElementById('enter-ar').hidden = !camera.arAvailable;
+```
+
+`startXr` も同じ方法で判定され、要求されたモードが利用できない場合は何もしません。判定をすり抜けたボタンが大きな失敗を起こすことはありません。なお、`xrSession` スクリプトはカメラリグのトランスフォーム、ARの透過、セッションのクリーンアップも管理してくれるため、本格的な体験にはスクリプトを、簡単なテストやシンプルなビューアーには要素APIを使うのがおすすめです。
 
 ほとんどの [Web Component の例](https://playcanvas.github.io/web-components/examples/) には、XR のサポートが統合されています。それらのソースコードを参照して、どのように行われているかを確認してください。
 

--- a/src/components/LiveExample/shell.js
+++ b/src/components/LiveExample/shell.js
@@ -5,7 +5,7 @@
 // when the docs are updated to track a new @playcanvas/web-components release
 // (the engine version should match the library's dev-pinned engine).
 export const ENGINE_VERSION = '2.21.4';
-export const PWC_VERSION = '0.17.0';
+export const PWC_VERSION = '0.18.0';
 
 const CDN = 'https://cdn.jsdelivr.net/npm';
 


### PR DESCRIPTION
Tracks library [0.18.0](https://github.com/playcanvas/web-components/releases). No new tags this time — but it moves defaults, which is the kind of release that quietly falsifies an attribute table and, here, the live examples too.

## Shadow cascades on `<pc-light>`

`cascade-blend`, `cascade-distribution` and `num-cascades` ([web-components#413](https://github.com/playcanvas/web-components/pull/413)), with a **Shadow Cascades** section covering what the three do together, why `shadow-distance` still bounds them, and that `shadow-resolution` is per cascade rather than a shared budget. The new example is linked from there — the engine has no cascade debug view, so the distribution slider looks inert without the split-distance plot that example draws.

## Defaults handed back to the engine

Four `pc-light` defaults and one `pc-camera` default were the library's own and are now the engine's ([#412](https://github.com/playcanvas/web-components/pull/412), [#411](https://github.com/playcanvas/web-components/pull/411)), so the tables were wrong:

| Attribute | Was | Now |
| --- | --- | --- |
| `normal-offset-bias` | 0.05 | 0 |
| `shadow-bias` | 0.2 | 0.05 |
| `shadow-distance` | 16 | 40 |
| `vsm-bias` | 0.01 | 0.0025 |
| `clear-stencil-buffer` | false | true |

`pc-camera` also gains `clear-depth`, which had no attribute despite `clear-depth-buffer` sitting beside it. Both tables were audited against `observedAttributes` and the elements' cached defaults rather than read by eye — that audit is what turned up the missing attributes too, and it now reports both tables matching the source exactly.

## XR availability changed shape

`xrAvailable` is gone, replaced by `arAvailable` and `vrAvailable`, so `xr.md` is corrected. Worth flagging: the PR message described an intermediate `isXrAvailable(type)` that **did not ship** — this follows the source, not the message.

The two getters are independent, which is the point. The old single getter tested VR only, so an AR-capable phone with no VR reported `false` while `startXr('immersive-ar')` would have worked. Each control now gates on the mode it starts.

## The examples needed real work

Handing the bias defaults back to the engine leaves every shadow-casting doc scene striped with shadow acne — badly enough that `pc-render` was unusable as documentation:

| 0.17.0 | 0.18.0 defaults |
| --- | --- |
| clean | whole scene striped |

**All 31 examples still reported "clean" from the console harness**, because acne is not an error. This was caught by rendering `pc-render` at both versions side by side and looking at them. A sweep of candidate attribute sets then found the minimum that restores the old look: `normal-offset-bias="0.05" shadow-bias="0.2"` on the casting light, with `shadow-distance` left at the new 40 — bias is the whole problem. Pinned in all 10 shadow-casting fences, en + ja, and re-rendered to confirm clean.

`pc-light`'s table now also carries a note that these defaults are the engine's own and the shadow-tuning ones are deliberately left untuned, so the next reader knows to expect this.

## Also here

- Collapses two leftover transform-only `<pc-entity>` wrappers around a `<pc-model>` in `pc-anim-clip.md` — the 0.17.0 pass missed them, and they contradicted the "no wrapper needed" guidance on the sibling page
- Links the new Splat Streaming example alongside the other splat examples from `pc-gsplat`
- `PWC_VERSION` → 0.18.0; the engine pin stays 2.21.4, so no fence URLs moved
- Mirrored into `i18n/ja` throughout

## Verification

- Attribute names **and defaults** match source for both elements (scripted audit, not eyeballed)
- 31/31 tags still resolve against the library's golden `TAGS` list, both directions
- 31 fences byte-identical en/ja apart from translated comments
- All 31 live examples boot at 0.18.0 with no console output
- `pc-render` and `pc-model` re-rendered and visually clean
- `npm run lint` clean over 1326 files; `npm run build` clean for en + ja

## For the reviewer

The pinned bias values are the part to scrutinise — they are load-bearing, not decoration, and a future tidy-up that removes them will bring the acne back. If you would rather the examples show the engine defaults honestly and accept the artifacts, that is a reasonable different call and I will revert that hunk.

Fixes #

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/developer-site/blob/main/.github/CONTRIBUTING.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
