### PR TITLE
docs: track Web Components 0.19.0 — click events and pc-scene exposure

### DIFF
--- a/docs/user-manual/web-components/tags/pc-entity.md
+++ b/docs/user-manual/web-components/tags/pc-entity.md
@@ -34,26 +34,39 @@ Listen to these events using [`addEventListener()`](https://developer.mozilla.or
 
 | Event | Description |
 | --- | --- |
+| `click` | Fired when a primary pointer button is pressed and then released over the entity. |
 | `pointerdown` | Fired when a pointer is pressed down on the entity. |
 | `pointerenter` | Fired when a pointer enters the entity. |
 | `pointerleave` | Fired when a pointer leaves the entity. |
 | `pointermove` | Fired when a pointer is moved over the entity. |
 | `pointerup` | Fired when a pointer is released from the entity. |
 
-You can also handle these events declaratively with inline `onpointer*` attributes. These are standard [inline event handlers](https://developer.mozilla.org/en-US/docs/Web/Events/Event_handlers#registering_onevent_handlers), compiled and run by the browser itself, so they behave exactly like `onclick` on any HTML element: setting the attribute (even at runtime) replaces the previous handler, removing it removes the handler, and within the handler `this` is the `<pc-entity>` element and `event` is the dispatched event.
+All six are delivered as [`PointerEvent`](https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent) objects and bubble up the element tree, so one listener on an ancestor can serve a whole subtree.
+
+You can also handle these events declaratively with inline `onclick` and `onpointer*` attributes. These are standard [inline event handlers](https://developer.mozilla.org/en-US/docs/Web/Events/Event_handlers#registering_onevent_handlers), compiled and run by the browser itself, so they behave exactly like `onclick` on any HTML element: setting the attribute (even at runtime) replaces the previous handler, removing it removes the handler, and within the handler `this` is the `<pc-entity>` element and `event` is the dispatched event.
 
 ```html
 <pc-entity name="cube"
            onpointerenter="this.entity.script.tweener.play(0)"
            onpointerleave="this.entity.script.tweener.play(1)"
-           onpointerdown="this.entity.script.tweener.play(2)">
+           onclick="this.entity.script.tweener.play(2)">
     <pc-render type="box"></pc-render>
 </pc-entity>
 ```
 
+### Clicks
+
+`click` is the one to reach for when you want click-to-select, and it is worth knowing why rather than composing it yourself from `pointerdown` and `pointerup`:
+
+* It requires the **primary** button, so a right-click does not fire it — `pointerup` alone does.
+* It requires a press *and* a release, so it does not fire at the start of every camera drag the way `pointerdown` does.
+* If the press and the release landed on different geometry, the click fires at their **nearest common ancestor** — dragging from one object onto its sibling clicks their shared parent, and dragging off onto the background clicks nothing at all. This is the same rule the browser applies to native clicks on nested HTML.
+
+A press the browser takes back — a touch it reinterprets as a scroll, say — is discarded rather than concluding as a click.
+
 ## Example
 
-Entity transforms compose down the hierarchy: the small cube is a *child* of the large one, so hover over the large cube and both move together. Try editing the parent's `rotation` or `scale`, or the inline `onpointer*` handlers:
+Entity transforms compose down the hierarchy: the small cube is a *child* of the large one, so hover over the large cube and both move together. Clicking either cube turns the pair — the child has no handler of its own, so its clicks bubble to the parent. Try editing the parent's `rotation` or `scale`, or the inline handlers:
 
 ```html live-example
 <pc-app>
@@ -66,7 +79,8 @@ Entity transforms compose down the hierarchy: the small cube is a *child* of the
         </pc-entity>
         <pc-entity name="parent" rotation="0 30 0" tags="interactive"
                    onpointerenter="this.entity.setLocalPosition(0, 0.25, 0)"
-                   onpointerleave="this.entity.setLocalPosition(0, 0, 0)">
+                   onpointerleave="this.entity.setLocalPosition(0, 0, 0)"
+                   onclick="this.entity.rotate(0, 45, 0)">
             <pc-render type="box"></pc-render>
             <pc-entity name="child" position="0.75 0.75 0" scale="0.5 0.5 0.5">
                 <pc-render type="box"></pc-render>

--- a/docs/user-manual/web-components/tags/pc-model.md
+++ b/docs/user-manual/web-components/tags/pc-model.md
@@ -29,7 +29,7 @@ Because the element's own transform belongs to the host, `position`, `rotation` 
 
 ## Attributes
 
-`<pc-model>` takes every attribute of [`<pc-entity>`](../pc-entity), including the `onpointer*` inline handlers, and adds `asset`.
+`<pc-model>` takes every attribute of [`<pc-entity>`](../pc-entity), including the `onclick` and `onpointer*` inline handlers, and adds `asset`.
 
 <div className="attribute-table">
 
@@ -56,10 +56,10 @@ Listen to these events using [`addEventListener()`](https://developer.mozilla.or
 
 Neither event bubbles, so listen on the element itself — or use a capture-phase listener on an ancestor to observe every model on the page.
 
-The host is registered for picking, so `<pc-model>` also fires the five pointer events a [`<pc-entity>`](../pc-entity) does — `pointerdown`, `pointerenter`, `pointerleave`, `pointermove` and `pointerup` — with the same inline `onpointer*` attribute forms. A whole model becomes clickable without a wrapper or a [`<pc-node>`](../pc-node):
+The host is registered for picking, so `<pc-model>` also fires the six pointer events a [`<pc-entity>`](../pc-entity) does — `click`, `pointerdown`, `pointerenter`, `pointerleave`, `pointermove` and `pointerup` — with the same inline handler attributes. A whole model becomes clickable without a wrapper or a [`<pc-node>`](../pc-node):
 
 ```html
-<pc-model asset="t-rex" onpointerdown="this.setAttribute('scale', '2 2 2')"></pc-model>
+<pc-model asset="t-rex" onclick="this.setAttribute('scale', '2 2 2')"></pc-model>
 ```
 
 Pointer events resolve to the nearest *listening* element, so a model that listens for nothing does not swallow events from a listening ancestor.

--- a/docs/user-manual/web-components/tags/pc-node.md
+++ b/docs/user-manual/web-components/tags/pc-node.md
@@ -94,13 +94,14 @@ A `<pc-material>` added to the document *after* a mapping referenced it is not p
 
 | Event | Description |
 | --- | --- |
+| `click` | Fired when a primary pointer button is pressed and then released over the node. |
 | `pointerdown` | Fired when a pointer is pressed down on the node. |
 | `pointerenter` | Fired when a pointer enters the node. |
 | `pointerleave` | Fired when a pointer leaves the node. |
 | `pointermove` | Fired when a pointer is moved over the node. |
 | `pointerup` | Fired when a pointer is released from the node. |
 
-The inline `onpointer*` attributes work here exactly as they do on [`<pc-entity>`](../pc-entity).
+The inline `onclick` and `onpointer*` attributes work here exactly as they do on [`<pc-entity>`](../pc-entity), including [how a click resolves](../pc-entity#clicks) when the press and release land on different geometry.
 
 ## Example
 

--- a/docs/user-manual/web-components/tags/pc-rigid-body.md
+++ b/docs/user-manual/web-components/tags/pc-rigid-body.md
@@ -73,3 +73,5 @@ Dynamic bodies falling onto a static ground. The sphere has `restitution="0.9"`,
 ## JavaScript Interface
 
 You can programmatically create and manipulate `<pc-rigid-body>` elements using the [RigidBodyComponentElement API](https://api.playcanvas.com/web-components/classes/RigidBodyComponentElement.html).
+
+The physics examples build on this tag: [Basic Physics](https://playcanvas.github.io/web-components/examples/basic-physics.html), [Physics Cluster](https://playcanvas.github.io/web-components/examples/physics-cluster.html), [Physics Joints](https://playcanvas.github.io/web-components/examples/physics-joints.html), [Ragdoll](https://playcanvas.github.io/web-components/examples/ragdoll.html) and [Vehicle Physics](https://playcanvas.github.io/web-components/examples/vehicle-physics.html).

--- a/docs/user-manual/web-components/tags/pc-scene.md
+++ b/docs/user-manual/web-components/tags/pc-scene.md
@@ -17,6 +17,7 @@ The `<pc-scene>` tag is used to define the scene.
 
 | Attribute | Type | Default | Description |
 | --- | --- | --- | --- |
+| `exposure` | Number | `"1"` | Overall brightness multiplier applied to the rendered image. Ignored while the scene uses physical light units |
 | `fog` | Enum | `"none"` | Fog type: `"none"` \| `"linear"` \| `"exp"` \| `"exp2"` |
 | `fog-color` | Color | `"1 1 1"` | Fog color as space-separated RGB values, hex code, or [named color](https://github.com/playcanvas/web-components/blob/main/src/colors.ts) |
 | `fog-density` | Number | `"0"` | Fog density for exponential fog types |

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-entity.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-entity.md
@@ -34,26 +34,39 @@ description: "pc-entity要素のリファレンス: 名前、変換、階層の�
 
 | イベント | 説明 |
 | --- | --- |
+| `click` | エンティティ上でプライマリボタンが押され、そして離されたときに発生します。 |
 | `pointerdown` | ポインターがエンティティ上で押下されたときに発生します。 |
 | `pointerenter` | ポインターがエンティティに入ったときに発生します。 |
 | `pointerleave` | ポインターがエンティティを離れたときに発生します。 |
 | `pointermove` | ポインターがエンティティ上で移動したときに発生します。 |
 | `pointerup` | ポインターがエンティティから解放されたときに発生します。 |
 
-これらのイベントは、インラインの `onpointer*` 属性を使って宣言的に処理することもできます。これらは標準の[インラインイベントハンドラー](https://developer.mozilla.org/ja/docs/Web/Events/Event_handlers)であり、ブラウザ自身によってコンパイル・実行されるため、任意のHTML要素の `onclick` とまったく同じように動作します。属性を（実行時であっても）設定すると以前のハンドラーが置き換えられ、削除するとハンドラーが削除されます。ハンドラー内では、`this` は `<pc-entity>` 要素であり、`event` はディスパッチされたイベントです。
+6つすべてが[`PointerEvent`](https://developer.mozilla.org/ja/docs/Web/API/PointerEvent)オブジェクトとして配信され、要素ツリーをバブリングします。そのため、祖先要素に1つリスナーを置けばサブツリー全体を扱えます。
+
+これらのイベントは、インラインの `onclick` および `onpointer*` 属性を使って宣言的に処理することもできます。これらは標準の[インラインイベントハンドラー](https://developer.mozilla.org/ja/docs/Web/Events/Event_handlers)であり、ブラウザ自身によってコンパイル・実行されるため、任意のHTML要素の `onclick` とまったく同じように動作します。属性を（実行時であっても）設定すると以前のハンドラーが置き換えられ、削除するとハンドラーが削除されます。ハンドラー内では、`this` は `<pc-entity>` 要素であり、`event` はディスパッチされたイベントです。
 
 ```html
 <pc-entity name="cube"
            onpointerenter="this.entity.script.tweener.play(0)"
            onpointerleave="this.entity.script.tweener.play(1)"
-           onpointerdown="this.entity.script.tweener.play(2)">
+           onclick="this.entity.script.tweener.play(2)">
     <pc-render type="box"></pc-render>
 </pc-entity>
 ```
 
+### クリック {#clicks}
+
+クリックによる選択を実装したいときに使うのが`click`です。`pointerdown`と`pointerup`から自分で組み立てるのではなく、これを使う理由を知っておく価値があります。
+
+* **プライマリ**ボタンを必要とするため、右クリックでは発生しません。`pointerup`だけではこれを区別できません。
+* 押下*と*解放の両方を必要とするため、`pointerdown`のようにカメラのドラッグ開始ごとに発生することはありません。
+* 押下と解放が別のジオメトリ上で起きた場合、クリックは両者の**最も近い共通の祖先**で発生します。あるオブジェクトから兄弟オブジェクトへドラッグすると共通の親でクリックが発生し、背景へドラッグして離すとどこでもクリックは発生しません。これは、ネストしたHTML上のネイティブなクリックにブラウザが適用するのと同じルールです。
+
+ブラウザが取り消した押下 — たとえばスクロールと解釈し直されたタッチ — はクリックとして成立せず、破棄されます。
+
 ## 例 {#example}
 
-エンティティのトランスフォームは階層を通じて合成されます。小さいキューブは大きいキューブの*子*なので、大きいキューブにポインタを乗せると両方が一緒に動きます。親の `rotation` や `scale`、インラインの `onpointer*` ハンドラを編集してみましょう:
+エンティティのトランスフォームは階層を通じて合成されます。小さいキューブは大きいキューブの*子*なので、大きいキューブにポインタを乗せると両方が一緒に動きます。どちらのキューブをクリックしても2つとも回転します。子にはハンドラがないため、そのクリックが親までバブリングするからです。親の `rotation` や `scale`、インラインのハンドラを編集してみましょう:
 
 ```html live-example
 <pc-app>
@@ -66,7 +79,8 @@ description: "pc-entity要素のリファレンス: 名前、変換、階層の�
         </pc-entity>
         <pc-entity name="parent" rotation="0 30 0" tags="interactive"
                    onpointerenter="this.entity.setLocalPosition(0, 0.25, 0)"
-                   onpointerleave="this.entity.setLocalPosition(0, 0, 0)">
+                   onpointerleave="this.entity.setLocalPosition(0, 0, 0)"
+                   onclick="this.entity.rotate(0, 45, 0)">
             <pc-render type="box"></pc-render>
             <pc-entity name="child" position="0.75 0.75 0" scale="0.5 0.5 0.5">
                 <pc-render type="box"></pc-render>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-model.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-model.md
@@ -29,7 +29,7 @@ description: "pc-model要素のリファレンス: GLBコンテナアセット�
 
 ## 属性 {#attributes}
 
-`<pc-model>`は[`<pc-entity>`](../pc-entity)のすべての属性（インラインの`onpointer*`ハンドラを含む）を取り、さらに`asset`を加えます。
+`<pc-model>`は[`<pc-entity>`](../pc-entity)のすべての属性（インラインの`onclick`・`onpointer*`ハンドラを含む）を取り、さらに`asset`を加えます。
 
 <div className="attribute-table">
 
@@ -56,10 +56,10 @@ description: "pc-model要素のリファレンス: GLBコンテナアセット�
 
 どちらのイベントもバブリングしないため、要素自身でリッスンしてください。あるいは、ページ上のすべてのモデルを監視するには、祖先要素でキャプチャフェーズのリスナーを使用します。
 
-ホストはピッキング対象として登録されるため、`<pc-model>`も[`<pc-entity>`](../pc-entity)と同じ5つのポインタイベント（`pointerdown`・`pointerenter`・`pointerleave`・`pointermove`・`pointerup`）を発生させ、インラインの`onpointer*`属性形式も同じように使えます。ラッパーや[`<pc-node>`](../pc-node)なしで、モデル全体がクリック可能になります。
+ホストはピッキング対象として登録されるため、`<pc-model>`も[`<pc-entity>`](../pc-entity)と同じ6つのポインタイベント（`click`・`pointerdown`・`pointerenter`・`pointerleave`・`pointermove`・`pointerup`）を発生させ、インラインのハンドラ属性も同じように使えます。ラッパーや[`<pc-node>`](../pc-node)なしで、モデル全体がクリック可能になります。
 
 ```html
-<pc-model asset="t-rex" onpointerdown="this.setAttribute('scale', '2 2 2')"></pc-model>
+<pc-model asset="t-rex" onclick="this.setAttribute('scale', '2 2 2')"></pc-model>
 ```
 
 ポインタイベントは最も近い*リッスンしている*要素に解決されるため、何もリッスンしていないモデルが、リッスンしている祖先要素のイベントを飲み込むことはありません。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-node.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-node.md
@@ -94,13 +94,14 @@ pc-node 'Wheel' is ambiguous in model 'car' - specify index: [0] Body/Wheel_FL/W
 
 | イベント | 説明 |
 | --- | --- |
+| `click` | ノード上でプライマリボタンが押され、そして離されたときに発生します。 |
 | `pointerdown` | ポインターがノード上で押下されたときに発生します。 |
 | `pointerenter` | ポインターがノードに入ったときに発生します。 |
 | `pointerleave` | ポインターがノードを離れたときに発生します。 |
 | `pointermove` | ポインターがノード上で移動したときに発生します。 |
 | `pointerup` | ポインターがノードから解放されたときに発生します。 |
 
-インラインの`onpointer*`属性は、[`<pc-entity>`](../pc-entity)とまったく同じように動作します。
+インラインの`onclick`・`onpointer*`属性は、[`<pc-entity>`](../pc-entity)とまったく同じように動作します。押下と解放が別のジオメトリ上で起きた場合に[クリックがどう解決されるか](../pc-entity#clicks)も同じです。
 
 ## 例 {#example}
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-rigid-body.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-rigid-body.md
@@ -73,3 +73,5 @@ description: "pc-rigid-body要素のリファレンス: rigid bodyの種類、�
 ## JavaScriptインターフェース {#javascript-interface}
 
 [RigidBodyComponentElement API](https://api.playcanvas.com/web-components/classes/RigidBodyComponentElement.html)を使用して、`<pc-rigid-body>`要素をプログラムで作成および操作できます。
+
+物理のサンプルはこのタグを土台にしています。[Basic Physics](https://playcanvas.github.io/web-components/examples/basic-physics.html)、[Physics Cluster](https://playcanvas.github.io/web-components/examples/physics-cluster.html)、[Physics Joints](https://playcanvas.github.io/web-components/examples/physics-joints.html)、[Ragdoll](https://playcanvas.github.io/web-components/examples/ragdoll.html)、[Vehicle Physics](https://playcanvas.github.io/web-components/examples/vehicle-physics.html)です。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-scene.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-scene.md
@@ -17,6 +17,7 @@ description: "pc-scene要素のリファレンス: pc-app内のSceneコンテナ
 
 | 属性 | タイプ | デフォルト | 説明 |
 | --- | --- | --- | --- |
+| `exposure` | Number | `"1"` | レンダリングされる画像全体の明るさの倍率。シーンが物理単位を使用している間は無視されます |
 | `fog` | Enum | `"none"` | フォグの種類：`"none"` \| `"linear"` \| `"exp"` \| `"exp2"` |
 | `fog-color` | Color | `"1 1 1"` | スペース区切りのRGB値、16進数コード、または[名前付きカラー](https://github.com/playcanvas/web-components/blob/main/src/colors.ts)としてのフォグの色 |
 | `fog-density` | Number | `"0"` | 指数フォグタイプの場合のフォグの密度 |

--- a/src/components/LiveExample/shell.js
+++ b/src/components/LiveExample/shell.js
@@ -5,7 +5,7 @@
 // when the docs are updated to track a new @playcanvas/web-components release
 // (the engine version should match the library's dev-pinned engine).
 export const ENGINE_VERSION = '2.21.4';
-export const PWC_VERSION = '0.18.0';
+export const PWC_VERSION = '0.19.0';
 
 const CDN = 'https://cdn.jsdelivr.net/npm';
 


### PR DESCRIPTION
Tracks library [0.19.0](https://github.com/playcanvas/web-components/releases). Two user-facing additions — small in the diff, worth some prose.

## `click` on entity-fronting elements

From [web-components#421](https://github.com/playcanvas/web-components/pull/421). Every entity-fronting element already *accepted* `onclick` — the platform compiles the attribute like any other `GlobalEventHandlers` member — but nothing ever dispatched a click, so the handler silently never ran. `pc-entity`, `pc-model` and `pc-node` all gain the event.

`pc-entity` gets a **Clicks** subsection, because the reason to prefer it over a hand-rolled `pointerdown`/`pointerup` pair isn't guessable from the event table:

- it needs the **primary** button, so a right-click doesn't fire it (`pointerup` alone does)
- it needs a press **and** a release, so it doesn't fire at the start of every camera drag (`pointerdown` does)
- when press and release land on different geometry it fires at their **nearest common ancestor** — the DOM's own rule for nested elements. Drag between siblings and their parent clicks; drag off onto the background and nothing does.

The `pc-entity` live example now uses it: clicking either cube turns the pair, which doubles as a demonstration of the child's clicks bubbling to the parent that holds the handler.

## `exposure` on `pc-scene`

From [web-components#417](https://github.com/playcanvas/web-components/pull/417) — the last scene-wide setting with no attribute behind it. A page lighting itself from an HDR sky previously had to reach for `app.scene.exposure` from script to stop the image clipping. Documented with the engine interaction the setter itself notes: it is ignored while the scene uses physical light units.

## Also here

- The new Vehicle Physics example is linked from `pc-rigid-body`, alongside the other physics examples
- `PWC_VERSION` → 0.19.0; the engine pin stays 2.21.4, so no fence URLs moved
- Mirrored into `i18n/ja` throughout

## Verification

The click semantics are **verified rather than transcribed** — real primary-button presses driven through CDP `Input.dispatchMouseEvent` over a purpose-built two-child scene:

| Input | Expected | Result |
| --- | --- | --- |
| press + release on a child with no handler | fires once at the parent | ✅ |
| press on one child, release on its sibling | fires at their common ancestor | ✅ |
| press on a child, release over the background | fires nothing | ✅ |
| right-button press + release on the parent | fires nothing | ✅ |

Worth recording that my **first attempt looked like a bubbling failure and wasn't**: `pc-entity`'s example lifts the cube on `pointerenter` and turns it on click, so screen coordinates computed before hovering no longer hit anything. That's why the check runs against an isolated scene with no hover handlers.

Also verified: all four touched attribute tables match source names *and* defaults (scripted audit); 31/31 tags resolve against the library's golden `TAGS` list; 31 fences byte-identical en/ja apart from translated comments; all 31 examples boot at 0.19.0 with no console output; `npm run lint` clean over 1326 files; `npm run build` clean for en + ja.

One run showed a transient jsDelivr fetch failure for `camera-controls.mjs` on `pc-anim-clip` — clean on re-run, and the same URL passes in the other examples that use it, so it's network flake rather than anything in this change.

Fixes #

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/developer-site/blob/main/.github/CONTRIBUTING.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
