### PR TITLE
Add Debug Drawing and Wide Lines pages

### DIFF
--- a/docs/user-manual/graphics/debug-drawing.md
+++ b/docs/user-manual/graphics/debug-drawing.md
@@ -1,0 +1,131 @@
+---
+title: Debug Drawing
+description: Draw wireframe shapes and lines for a single frame with WireRenderer, to visualize what your scene is doing.
+---
+
+Some things are hard to debug by reading numbers: whether a bounding box is where you think it is, which way a spline is heading, what a second camera can actually see. Debug drawing lets you put that geometry on screen for a frame so you can look at it.
+
+Everything on this page is **immediate mode**: geometry lasts one frame and is discarded once that frame has been rendered. To keep something visible, issue it again every frame from an update handler.
+
+## WireRenderer
+
+`WireRenderer` draws wireframe shapes. Create one and keep it around:
+
+```javascript
+import { Color, Vec3, WireRenderer } from 'playcanvas';
+
+const wire = new WireRenderer(app);
+
+app.on('update', (dt) => {
+    wire.color = Color.RED;
+    wire.sphere(new Vec3(0, 1, 0), 2);
+});
+```
+
+### State lives on the renderer
+
+Rather than passing options to every call, the renderer holds the state its shapes use:
+
+| Property | Meaning |
+| --- | --- |
+| `color` | The color shapes are drawn in. Alpha is respected. |
+| `layer` | The layer to draw into, or `null` for the immediate layer. |
+| `depthTest` | Whether shapes are hidden by geometry in front of them. |
+| `segments` | How many line segments approximate a full circle. |
+| `transform` | A matrix applied to every point, or `null`. |
+
+Set it once and draw as much as you like — drawing many shapes with the same state allocates nothing:
+
+```javascript
+wire.color = Color.GREEN;
+
+for (const item of items) {
+    wire.sphere(item.getPosition(), item.radius);
+}
+```
+
+A second set of state is simply a second renderer. Instances hold no GPU resources, and instances sharing a layer and depth test mode are drawn together, so using several costs nothing extra:
+
+```javascript
+const solid = new WireRenderer(app);
+
+const xray = new WireRenderer(app);
+xray.depthTest = false;   // drawn on top of everything
+```
+
+`transform` is useful for drawing a group of shapes in some other space. Set it, draw, and every point is transformed on the way out:
+
+```javascript
+wire.transform = entity.getWorldTransform();
+wire.boxMinMax(localMin, localMax);   // drawn in the entity's space
+wire.transform = null;
+```
+
+### Shapes
+
+```javascript
+wire.line(start, end);
+wire.lines(positions, colors);          // Vec3[] pairs, optional Color[] per point
+wire.linesPacked(positions, colors);    // packed xyz / rgba numbers, the fastest form
+wire.polyline(positions, colors);       // an open strip
+wire.loop(positions, colors);           // a closed strip
+
+wire.box(box);                          // BoundingBox or OrientedBox
+wire.boxMinMax(min, max);
+wire.sphere(center, radius);
+wire.circle(center, normal, radius);
+wire.cylinder(start, end, radius);
+wire.capsule(start, end, radius);
+wire.cone(apex, direction, angle, length);
+wire.plane(center, normal, size);
+wire.point(position, size);
+wire.arrow(from, to);
+wire.axes(matrix, size);                // red, green and blue for x, y and z
+wire.frustum(source);                   // a camera, or a view-projection matrix
+wire.light(lightComponent);             // the light's shape and extent, in its own color
+```
+
+For the line functions, `colors` is optional. Omit it and the renderer's `color` is used for everything; supply one color per point and each segment fades between its ends.
+
+`linesPacked` takes plain arrays or `Float32Array`s of numbers rather than `Vec3` and `Color` instances, which makes it the cheapest way to submit a lot of geometry. Note that leaving `colors` off is a larger saving than the choice of array type — a uniform color avoids writing a color per vertex entirely.
+
+### Visualizing a camera
+
+`wire.frustum()` draws the volume a camera can see. It works on a camera that is not currently rendering, which is the interesting case — you can fly one camera around while looking through another:
+
+```javascript
+wire.color = Color.YELLOW;
+wire.frustum(observerEntity.camera);
+```
+
+Combined with `Frustum#containsAabb` this makes culling visible:
+
+```javascript
+const viewProjection = new Mat4().mul2(observer.camera.projectionMatrix, viewMatrix);
+frustum.setFromMat4(viewProjection);
+
+for (const meshInstance of meshInstances) {
+    const inside = frustum.containsAabb(meshInstance.aabb);
+    (inside ? greenWire : redWire).box(meshInstance.aabb);
+}
+```
+
+### A note on `plane`
+
+The rotation of the square within its plane is derived from the normal you pass, and no such derivation is continuous over every direction. An animated normal will therefore make the square appear to jump as it passes the direction where that derivation switches. To rotate a square smoothly, pass a fixed normal and drive `transform` instead.
+
+This does not affect `circle`, `cylinder`, `capsule` or `cone`, whose rings are symmetric about their axis.
+
+## Thick lines
+
+Everything above draws single pixel lines, which is what you want for a debugging overlay. For lines that are part of the rendered scene — a highlighted path, a road network, an annotation — use [`WideLineRenderer`](./wide-lines.md) instead. It supports width in screen pixels or world units, caps, joins, dashes and gradients, and it is retained rather than immediate: you add a line once and it stays until you remove it.
+
+## Performance counters
+
+Debug drawing shows you *where* things are. To see how long they take, use [MiniStats](/user-manual/optimization/mini-stats).
+
+## Examples
+
+- [Wire Shapes](https://playcanvas.github.io/#/debug/wire-shapes) — every shape, animated
+- [Frustum Culling](https://playcanvas.github.io/#/debug/frustum-culling) — a camera's view volume, and bounds colored by whether it contains them
+- [Lines](https://playcanvas.github.io/#/debug/lines) — all of the line functions at once

--- a/docs/user-manual/graphics/wide-lines.md
+++ b/docs/user-manual/graphics/wide-lines.md
@@ -1,0 +1,96 @@
+---
+title: Wide Lines
+description: Render thick lines with caps, joins, dashes and gradients using WideLineRenderer, for paths, annotations and other line geometry that is part of your scene.
+---
+
+WebGL and WebGPU can only draw lines one pixel wide. `WideLineRenderer` works around that by rendering each segment as camera-facing geometry, giving you lines with real thickness, rounded ends, mitred corners, dashes and colour gradients.
+
+Use it for line geometry that is part of the rendered scene — a highlighted route, a road network, a measurement annotation, a trajectory. For single pixel wireframes used to inspect a scene while developing, see [Debug Drawing](./debug-drawing.md) instead.
+
+## Lines and renderers
+
+There are two pieces. A `WideLine` holds the point data for one line. A `WideLineRenderer` owns a set of lines and draws them:
+
+```javascript
+import { LINECAP_ROUND, LINEJOIN_ROUND, WideLine, WideLineRenderer } from 'playcanvas';
+
+const renderer = new WideLineRenderer(app);
+const line = new WideLine();
+
+line.set(
+    new Float32Array([-2, 0, 0, 0, 1, 0, 2, 0, 0]),   // three points, packed xyz
+    new Float32Array([1, 0, 0, 1, 1, 0, 0, 1, 1]),    // a colour per point, packed rgb
+    new Float32Array([4, 12, 4])                       // a width per point
+);
+line.cap = LINECAP_ROUND;
+line.join = LINEJOIN_ROUND;
+
+renderer.add(line);
+
+app.on('destroy', () => renderer.destroy());
+```
+
+Unlike debug drawing, this is **retained**: add a line once and it stays until you `remove()` it. There is no need to reissue it every frame.
+
+Colours and widths can each be given per point, or as a single value used by every point.
+
+## Styling a line
+
+These are properties of the `WideLine`, so each line in a renderer can look different:
+
+| Property | Purpose |
+| --- | --- |
+| `cap` | How the ends are finished — `LINECAP_BUTT`, `LINECAP_ROUND` or `LINECAP_SQUARE`. |
+| `join` | How corners are joined — `LINEJOIN_MITER`, `LINEJOIN_BEVEL` or `LINEJOIN_ROUND`. |
+| `closed` | Joins the last point back to the first. |
+| `dashLength`, `gapLength` | Dash pattern. Leave `dashLength` at zero for a solid line. |
+| `dashOffset` | Shifts the dash pattern along the line, for marching-ants effects. |
+
+## Updating point data
+
+`setPositions`, `setColors` and `setWidths` each replace their data while keeping the point count, reusing the line's existing storage:
+
+```javascript
+line.setPositions(updatedPositions);
+```
+
+Use `set()` when the number of points itself needs to change.
+
+## Renderer settings
+
+| Property | Purpose |
+| --- | --- |
+| `widthUnits` | `LINEWIDTH_SCREEN` (default) measures width in screen pixels, so lines keep their thickness at any distance. `LINEWIDTH_WORLD` measures in world units, so they shrink with distance like geometry. |
+| `layer` | The layer to render into. Defaults to the Immediate layer. |
+| `depthTest`, `depthWrite` | Interaction with the depth buffer. Both default to true. |
+| `enabled` | Turns the whole renderer off. |
+| `capacity` | Instance buffer size, measured in segments. |
+
+## Performance
+
+Every segment owned by a renderer is drawn as one GPU instance, and all of them are submitted together — so adding more `WideLine` objects does not add draw calls. A renderer with visible segments costs one draw call per camera that renders its layer.
+
+The trade-off is that **changing any line rebuilds the instance data for every line that renderer owns.** So mixing rarely-changing and frequently-changing lines in one renderer makes the static data rebuild needlessly. There is no static/dynamic flag; you separate them with two renderers:
+
+```javascript
+const staticLines = new WideLineRenderer(app);
+const dynamicLines = new WideLineRenderer(app);
+
+staticLines.add(roadNetwork);       // built and uploaded once
+dynamicLines.add(projectilePath);   // updated every frame
+```
+
+`capacity` grows automatically, but setting it up front avoids GPU buffer reallocations when you know the maximum segment count. `clear()` removes the lines while keeping the capacity for reuse.
+
+The batch is not frustum culled, so set `enabled` to `false` when none of its lines need drawing.
+
+## Limitations
+
+- **Rendering is opaque.** Colours are rgb; the alpha component of a `Color` is ignored and transparent lines are not supported.
+- Call `destroy()` to release the mesh, material and instance buffer. Lines detached this way remain usable and can be added to another renderer.
+
+## Examples
+
+- [Wide Line](https://playcanvas.github.io/#/graphics/wide-line)
+- [Wide Lines Styles](https://playcanvas.github.io/#/graphics/wide-lines-styles) — caps, joins, dashes and gradients side by side
+- [Wide Lines Dynamic](https://playcanvas.github.io/#/graphics/wide-lines-dynamic) — updating point data every frame

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/debug-drawing.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/debug-drawing.md
@@ -1,0 +1,131 @@
+---
+title: デバッグ描画
+description: WireRenderer で 1 フレームだけワイヤーフレームの形状やラインを描画し、シーンで何が起きているかを可視化します。
+---
+
+数値を読むだけでは調べにくいものがあります。バウンディングボックスが想定した位置にあるか、スプラインがどちらへ向かっているか、2 台目のカメラに実際に何が見えているか、といったものです。デバッグ描画を使うと、そうしたジオメトリを 1 フレームだけ画面に出して目で確認できます。
+
+このページで扱うものはすべて **イミディエイトモード** です。ジオメトリの寿命は 1 フレームで、そのフレームが描画された時点で破棄されます。表示を継続したい場合は、update ハンドラーから毎フレーム発行してください。
+
+## WireRenderer
+
+`WireRenderer` はワイヤーフレームの形状を描画します。1 つ作成して保持しておきます。
+
+```javascript
+import { Color, Vec3, WireRenderer } from 'playcanvas';
+
+const wire = new WireRenderer(app);
+
+app.on('update', (dt) => {
+    wire.color = Color.RED;
+    wire.sphere(new Vec3(0, 1, 0), 2);
+});
+```
+
+### 状態はレンダラーが保持します
+
+呼び出しごとにオプションを渡すのではなく、形状が使用する状態をレンダラーが保持します。
+
+| プロパティ | 意味 |
+| --- | --- |
+| `color` | 形状を描画する色です。アルファも反映されます。 |
+| `layer` | 描画先のレイヤーです。`null` の場合はイミディエイトレイヤーになります。 |
+| `depthTest` | 手前のジオメトリによって形状が隠されるかどうかです。 |
+| `segments` | 円 1 周を近似するラインセグメントの数です。 |
+| `transform` | すべての頂点に適用される行列です。不要な場合は `null` です。 |
+
+一度設定すれば、あとは好きなだけ描画できます。同じ状態で多数の形状を描画してもメモリ確保は発生しません。
+
+```javascript
+wire.color = Color.GREEN;
+
+for (const item of items) {
+    wire.sphere(item.getPosition(), item.radius);
+}
+```
+
+2 組目の状態が必要なら、レンダラーをもう 1 つ作成するだけです。インスタンスは GPU リソースを持たず、レイヤーと深度テストの設定が同じインスタンスはまとめて描画されるため、複数使用しても追加のコストはありません。
+
+```javascript
+const solid = new WireRenderer(app);
+
+const xray = new WireRenderer(app);
+xray.depthTest = false;   // すべての手前に描画されます
+```
+
+`transform` は、形状のグループを別の空間で描画したいときに便利です。設定して描画すれば、すべての頂点が出力時に変換されます。
+
+```javascript
+wire.transform = entity.getWorldTransform();
+wire.boxMinMax(localMin, localMax);   // エンティティの空間で描画されます
+wire.transform = null;
+```
+
+### 形状
+
+```javascript
+wire.line(start, end);
+wire.lines(positions, colors);          // Vec3[] のペア、点ごとの Color[] は省略可
+wire.linesPacked(positions, colors);    // xyz / rgba を詰めた数値配列。最も高速な形式
+wire.polyline(positions, colors);       // 開いたストリップ
+wire.loop(positions, colors);           // 閉じたストリップ
+
+wire.box(box);                          // BoundingBox または OrientedBox
+wire.boxMinMax(min, max);
+wire.sphere(center, radius);
+wire.circle(center, normal, radius);
+wire.cylinder(start, end, radius);
+wire.capsule(start, end, radius);
+wire.cone(apex, direction, angle, length);
+wire.plane(center, normal, size);
+wire.point(position, size);
+wire.arrow(from, to);
+wire.axes(matrix, size);                // x, y, z をそれぞれ赤、緑、青で描画します
+wire.frustum(source);                   // カメラ、またはビュープロジェクション行列
+wire.light(lightComponent);             // ライトの形状と範囲を、そのライト自身の色で描画します
+```
+
+ライン系の関数では `colors` は省略可能です。省略するとすべてにレンダラーの `color` が使用されます。点ごとに色を渡した場合は、各セグメントが両端の色の間で補間されます。
+
+`linesPacked` は `Vec3` や `Color` のインスタンスではなく数値の通常配列または `Float32Array` を受け取るため、大量のジオメトリを送るには最も低コストです。なお、配列の型を選ぶことよりも `colors` を省略することのほうが節約になります。単色であれば、頂点ごとに色を書き込む処理自体が不要になるためです。
+
+### カメラの可視化
+
+`wire.frustum()` はカメラが見ることのできる範囲を描画します。現在描画に使用されていないカメラに対しても機能し、こちらが本来の使いどころです。あるカメラを動かしながら、別のカメラを通してそれを眺めることができます。
+
+```javascript
+wire.color = Color.YELLOW;
+wire.frustum(observerEntity.camera);
+```
+
+`Frustum#containsAabb` と組み合わせると、カリングの様子を可視化できます。
+
+```javascript
+const viewProjection = new Mat4().mul2(observer.camera.projectionMatrix, viewMatrix);
+frustum.setFromMat4(viewProjection);
+
+for (const meshInstance of meshInstances) {
+    const inside = frustum.containsAabb(meshInstance.aabb);
+    (inside ? greenWire : redWire).box(meshInstance.aabb);
+}
+```
+
+### `plane` についての注意
+
+平面内での正方形の回転は、渡された法線から導出されます。そしてこの導出をすべての方向にわたって連続にすることはできません。そのため法線をアニメーションさせると、導出が切り替わる方向を通過する際に正方形が飛んだように見えます。正方形を滑らかに回転させたい場合は、法線を固定して `transform` を動かしてください。
+
+`circle`、`cylinder`、`capsule`、`cone` はリングが軸に対して対称なため、この影響を受けません。
+
+## 太いライン
+
+上記はすべて 1 ピクセル幅のラインを描画します。デバッグ用のオーバーレイにはこれが適しています。描画されるシーンの一部となるライン、たとえば強調表示された経路、道路網、注釈などには、代わりに [太いライン](./wide-lines.md) を使用してください。スクリーンピクセル単位またはワールド単位の太さ、キャップ、ジョイン、破線、グラデーションに対応しており、イミディエイトではなく保持型です。ラインを一度追加すれば、削除するまで残ります。
+
+## パフォーマンスカウンター
+
+デバッグ描画は物事が *どこにあるか* を示します。それらにどれだけ時間がかかっているかを見るには、[MiniStats](/user-manual/optimization/mini-stats) を使用してください。
+
+## サンプル
+
+- [Wire Shapes](https://playcanvas.github.io/#/debug/wire-shapes) — すべての形状をアニメーション付きで表示します
+- [Frustum Culling](https://playcanvas.github.io/#/debug/frustum-culling) — カメラの視錐台と、それに含まれるかどうかで色分けされたバウンディングボックス
+- [Lines](https://playcanvas.github.io/#/debug/lines) — ライン系関数のすべてを一度に使用します

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/wide-lines.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/wide-lines.md
@@ -1,0 +1,96 @@
+---
+title: 太いライン
+description: WideLineRenderer を使用して、キャップ、ジョイン、破線、グラデーションを備えた太いラインを描画します。シーンの一部となる経路や注釈などのラインジオメトリに適しています。
+---
+
+WebGL と WebGPU は 1 ピクセル幅のラインしか描画できません。`WideLineRenderer` は各セグメントをカメラに面したジオメトリとして描画することでこれを回避し、実際の太さ、丸い端点、マイター処理された角、破線、色のグラデーションを備えたラインを提供します。
+
+描画されるシーンの一部となるラインジオメトリに使用してください。強調表示された経路、道路網、寸法の注釈、軌跡などです。開発中にシーンを確認するための 1 ピクセル幅のワイヤーフレームには、代わりに [デバッグ描画](./debug-drawing.md) を参照してください。
+
+## ラインとレンダラー
+
+構成要素は 2 つあります。`WideLine` は 1 本のラインの点データを保持します。`WideLineRenderer` はラインの集合を所有し、それらを描画します。
+
+```javascript
+import { LINECAP_ROUND, LINEJOIN_ROUND, WideLine, WideLineRenderer } from 'playcanvas';
+
+const renderer = new WideLineRenderer(app);
+const line = new WideLine();
+
+line.set(
+    new Float32Array([-2, 0, 0, 0, 1, 0, 2, 0, 0]),   // 3 点、xyz を詰めた配列
+    new Float32Array([1, 0, 0, 1, 1, 0, 0, 1, 1]),    // 点ごとの色、rgb を詰めた配列
+    new Float32Array([4, 12, 4])                       // 点ごとの太さ
+);
+line.cap = LINECAP_ROUND;
+line.join = LINEJOIN_ROUND;
+
+renderer.add(line);
+
+app.on('destroy', () => renderer.destroy());
+```
+
+デバッグ描画と異なり、こちらは **保持型** です。ラインを一度追加すれば `remove()` するまで残ります。毎フレーム再発行する必要はありません。
+
+色と太さは、点ごとに指定することも、すべての点で使用される単一の値として指定することもできます。
+
+## ラインのスタイル設定
+
+以下は `WideLine` のプロパティなので、1 つのレンダラー内の各ラインをそれぞれ異なる見た目にできます。
+
+| プロパティ | 用途 |
+| --- | --- |
+| `cap` | 端点の処理方法です。`LINECAP_BUTT`、`LINECAP_ROUND`、`LINECAP_SQUARE` があります。 |
+| `join` | 角の接続方法です。`LINEJOIN_MITER`、`LINEJOIN_BEVEL`、`LINEJOIN_ROUND` があります。 |
+| `closed` | 最後の点を最初の点に接続します。 |
+| `dashLength`、`gapLength` | 破線のパターンです。実線にする場合は `dashLength` を 0 のままにします。 |
+| `dashOffset` | 破線パターンをラインに沿ってずらします。マーチングアント効果などに使用します。 |
+
+## 点データの更新
+
+`setPositions`、`setColors`、`setWidths` は点の数を保ったままそれぞれのデータを置き換え、ラインの既存のストレージを再利用します。
+
+```javascript
+line.setPositions(updatedPositions);
+```
+
+点の数自体を変更する必要がある場合は `set()` を使用してください。
+
+## レンダラーの設定
+
+| プロパティ | 用途 |
+| --- | --- |
+| `widthUnits` | `LINEWIDTH_SCREEN`（デフォルト）は太さをスクリーンピクセルで測るため、距離が変わってもラインの太さは保たれます。`LINEWIDTH_WORLD` はワールド単位で測るため、ジオメトリと同様に距離に応じて細くなります。 |
+| `layer` | 描画先のレイヤーです。デフォルトはイミディエイトレイヤーです。 |
+| `depthTest`、`depthWrite` | 深度バッファとの関係を制御します。どちらもデフォルトは true です。 |
+| `enabled` | レンダラー全体を無効にします。 |
+| `capacity` | インスタンスバッファのサイズです。セグメント数で測ります。 |
+
+## パフォーマンス
+
+レンダラーが所有するすべてのセグメントは 1 つの GPU インスタンスとして描画され、それらはまとめて送信されます。そのため `WideLine` オブジェクトを増やしてもドローコールは増えません。表示中のセグメントを持つレンダラーは、そのレイヤーを描画するカメラごとに 1 回のドローコールを消費します。
+
+代わりに、**いずれかのラインを変更すると、そのレンダラーが所有するすべてのラインのインスタンスデータが再構築されます。** そのため、ほとんど変化しないラインと頻繁に変化するラインを 1 つのレンダラーに混在させると、静的なデータが無駄に再構築されます。静的・動的を切り替えるフラグはなく、2 つのレンダラーに分けて対応します。
+
+```javascript
+const staticLines = new WideLineRenderer(app);
+const dynamicLines = new WideLineRenderer(app);
+
+staticLines.add(roadNetwork);       // 一度だけ構築してアップロードされます
+dynamicLines.add(projectilePath);   // 毎フレーム更新されます
+```
+
+`capacity` は自動的に拡張されますが、最大セグメント数が分かっている場合は事前に設定することで GPU バッファの再確保を避けられます。`clear()` はラインを削除しつつ、再利用のために容量を保持します。
+
+このバッチは視錐台カリングされません。描画すべきラインが 1 本もない場合は `enabled` を `false` にしてください。
+
+## 制限事項
+
+- **描画は不透明です。** 色は rgb であり、`Color` のアルファ成分は無視されます。半透明のラインには対応していません。
+- メッシュ、マテリアル、インスタンスバッファを解放するには `destroy()` を呼び出してください。この方法で切り離されたラインはそのまま使用でき、別のレンダラーに追加できます。
+
+## サンプル
+
+- [Wide Line](https://playcanvas.github.io/#/graphics/wide-line)
+- [Wide Lines Styles](https://playcanvas.github.io/#/graphics/wide-lines-styles) — キャップ、ジョイン、破線、グラデーションを並べて比較します
+- [Wide Lines Dynamic](https://playcanvas.github.io/#/graphics/wide-lines-dynamic) — 毎フレーム点データを更新します

--- a/sidebars.js
+++ b/sidebars.js
@@ -872,6 +872,8 @@ const sidebars = {
         },
         'user-manual/graphics/particles',
         'user-manual/graphics/layers/index',
+        'user-manual/graphics/wide-lines',
+        'user-manual/graphics/debug-drawing',
         {
           type: 'category',
           label: 'Advanced Rendering',


### PR DESCRIPTION
Neither `WireRenderer` nor `WideLineRenderer` had a user manual page. Adds one for each, under Graphics.

### Debug Drawing

`WireRenderer`, added in [playcanvas/engine#9288](https://github.com/playcanvas/engine/pull/9288). Covers the immediate-mode lifetime, why state lives on the renderer rather than in per-call options, the shape list, and visualizing a camera's view volume alongside `Frustum#containsAabb`.

Also documents the one behaviour that surprises people: the in-plane rotation of `plane` is derived from the normal you pass, and no such derivation is continuous over every direction — so an animated normal makes the square appear to jump. Pass a fixed normal and drive `transform` instead.

### Wide Lines

`WideLineRenderer`, which has been in the engine for a while with no page at all. Covers lines versus renderers, the retained rather than immediate lifetime, styling, screen versus world width units, and the performance shape that matters most: changing one line rebuilds the instance data for *every* line that renderer owns, so static and dynamic lines belong in separate renderers.

### Notes

- The two pages cross-reference each other, since "which of these do I want" is the first question a reader has. Debug drawing is for single-pixel wireframes you look at while developing; wide lines are for line geometry that is part of the scene.
- Example links use the `https://playcanvas.github.io/#/<category>/<example>` form. The three `wide-line*` links work today; the three `debug/*` links go live with the engine release that ships #9288.
- Japanese translations included for both pages, per `AGENTS.md`.
- `npm run lint` clean.

**Gate on the engine release containing #9288.** That PR is merged, but the `WireRenderer` half describes an API that is not in a published release yet.
