### PR TITLE
docs: restructure the Web Components tag index by role, and type the reference attributes

### DIFF
--- a/docs/user-manual/web-components/attributes.md
+++ b/docs/user-manual/web-components/attributes.md
@@ -1,6 +1,6 @@
 ---
 title: Attributes
-description: "How PlayCanvas Web Component attributes parse values: shared defaults contract, booleans, numbers, enums, vectors, colors, and entity references."
+description: "How PlayCanvas Web Component attributes parse values: the shared defaults contract, the Type column, booleans, numbers, enums, vectors, colors, asset and material IDs, and entity references."
 ---
 
 Every PlayCanvas Web Component is configured through HTML attributes. All attributes follow the same set of conventions, so once you have learned them, you can predict how any tag will behave.
@@ -20,6 +20,21 @@ The *Default* column in each tag's attribute table shows the value that applies 
 Invalid values never reach the engine. Instead, you get a console warning naming the attribute and the expected format — keep the console open while authoring and typos surface immediately.
 
 [`<pc-node>`](tags/pc-node.md) is the one exception to the middle row. Its attributes are overrides against a node inside a loaded model, so an absent attribute restores the value that model was authored with rather than the engine default.
+
+## The Type Column
+
+The *Type* column of each attribute table names how a value is written. Every type is defined on this page:
+
+| Type | Written as |
+| --- | --- |
+| Boolean | `"true"`, `"false"`, or bare presence — see [Booleans](#booleans) |
+| Number | Any finite number — see [Numbers](#numbers) |
+| Enum | One of a fixed set of names, listed in the attribute's description — see [Enums](#enums) |
+| Vector2, Vector3, Vector4 | Two, three or four space-separated numbers — see [Vectors](#vectors) |
+| Color | A CSS color name, a hex code, or three or four numbers — see [Colors](#colors) |
+| String | Free text: a name, a path, a JSON object |
+| Asset ID, Material ID | The `id` of a [`<pc-asset>`](tags/pc-asset.md) or a [`<pc-material>`](tags/pc-material.md) — see [Asset and Material IDs](#asset-and-material-ids) |
+| Entity Reference | An entity `name`, or a `#` selector — see [Entity References](#entity-references) |
 
 ## Booleans
 
@@ -84,6 +99,19 @@ Color attributes accept any of three formats:
 <pc-camera clear-color="#f0f8ff"></pc-camera>
 <pc-light color="1 0.8 0.6"></pc-light>
 ```
+
+## Asset and Material IDs
+
+Resources are declared once, as direct children of [`<pc-app>`](tags/pc-app.md), and referenced by the `id` you give them. An Asset ID attribute names a [`<pc-asset>`](tags/pc-asset.md); a Material ID attribute names a [`<pc-material>`](tags/pc-material.md):
+
+```html
+<pc-asset id="tiles" src="tiles.png"></pc-asset>
+<pc-material id="floor" diffuse-map="tiles"></pc-material>
+<!-- ... -->
+<pc-render type="plane" material="floor"></pc-render>
+```
+
+The value is the element's own `id`, written bare — no `#`, because it is a lookup in the application's registry rather than a CSS selector. Each attribute's description says which asset type it accepts. An `id` that matches no declared resource has no effect: the element keeps what it had, and [`<pc-model>`](tags/pc-model.md) additionally logs a warning naming the asset it could not find.
 
 ## Entity References
 

--- a/docs/user-manual/web-components/tags/index.md
+++ b/docs/user-manual/web-components/tags/index.md
@@ -1,19 +1,137 @@
 ---
 title: Tag Reference
-description: "Alphabetical index of PlayCanvas Web Component tags with short summaries linking to full attribute and usage documentation for each element."
+description: "Every PlayCanvas Web Component tag grouped by role, the document structure they form, and a link to each element's attributes, events and placement rules."
 ---
 
-Here is a complete list of the tags that are available in PlayCanvas Web Components.
+Every PlayCanvas Web Component tag is listed here, grouped by role, with the document structure they form and a reference page for each one.
 
-The attributes of every tag share the same value conventions: an absent (or removed) attribute means the engine default applies, and an invalid value logs a console warning and falls back to the default. See [Attributes](../attributes.md) for how booleans, numbers, enums, vectors and colors are written.
+## How the Tags Fit Together
 
-Tags also have placement rules — each tag's page notes the parent it requires. A misplaced element logs a console warning naming the parents it would accept, so keep the console open while authoring.
+Every document has the same shape. [`<pc-app>`](pc-app) holds the resources and one [`<pc-scene>`](pc-scene); the scene holds entities; an entity holds one of each component tag it needs, plus child entities:
 
-Three tags front an engine entity, and a component tag can sit inside any of them: [`<pc-entity>`](pc-entity), [`<pc-model>`](pc-model) and [`<pc-node>`](pc-node). So a component placed inside a model attaches to that model, and one placed inside a node attaches to the node — both take the same component children an entity does.
+```html
+<pc-app>
+    <!-- Resources are declared once and referenced by id -->
+    <pc-asset id="sky" src="sky.webp"></pc-asset>
+    <pc-asset id="robot" src="robot.glb"></pc-asset>
+    <pc-material id="gold" diffuse="#d4af37" metalness="1"></pc-material>
+    <pc-wasm name="Ammo" glue="ammo.js" wasm="ammo.wasm"></pc-wasm>
+    <pc-scene>
+        <pc-sky asset="sky"></pc-sky>
+        <!-- An entity takes one of each component tag, and nests entities and models -->
+        <pc-entity name="camera" position="0 2 6">
+            <pc-camera></pc-camera>
+        </pc-entity>
+        <pc-entity name="crate" position="0 3 0">
+            <pc-render type="box" material="gold"></pc-render>
+            <pc-collision></pc-collision>
+            <pc-rigid-body type="dynamic"></pc-rigid-body>
+        </pc-entity>
+        <!-- A model is an entity that instantiates a GLB; a node binds to a node inside it -->
+        <pc-model asset="robot">
+            <pc-anim clip="idle">
+                <pc-anim-clip name="idle"></pc-anim-clip>
+            </pc-anim>
+            <pc-node name="head">
+                <pc-light type="spot"></pc-light>
+            </pc-node>
+        </pc-model>
+    </pc-scene>
+</pc-app>
+```
+
+Three tags front an engine entity, and a component tag can sit inside any of them: [`<pc-entity>`](pc-entity), [`<pc-model>`](pc-model) and [`<pc-node>`](pc-node). A component placed inside a model attaches to that model's host entity, and one placed inside a node attaches to the bound node — both take the same component children an entity does.
+
+Each tag's page states the parent it requires. A misplaced element logs a console warning naming the parents it would accept, so keep the console open while authoring.
+
+## Tags by Role
+
+### Structure
+
+The five tags that form the document: the application, its scene, and the three that front an entity.
+
+| Tag | Description |
+| --- | --- |
+| [`<pc-app>`](pc-app) | Defines the root element of an application: its graphics device, and the resources and scene it holds. |
+| [`<pc-scene>`](pc-scene) | Defines the scene, with the fog, exposure and gravity that apply to everything inside it. |
+| [`<pc-entity>`](pc-entity) | Defines an entity: a named transform that hosts component tags and child entities. |
+| [`<pc-model>`](pc-model) | Defines an entity that instantiates a 3D model from a GLB file. |
+| [`<pc-node>`](pc-node) | Binds to a node inside a loaded model to override it. |
+
+### Resources
+
+Direct children of `<pc-app>`, declared once and referenced by `id` from the tags that use them.
+
+| Tag | Description |
+| --- | --- |
+| [`<pc-asset>`](pc-asset) | Defines an asset to be loaded by your application. |
+| [`<pc-material>`](pc-material) | Defines a material that render components can reference. |
+| [`<pc-wasm>`](pc-wasm) | Defines a WebAssembly module, such as the Ammo physics engine. |
+
+### Rendering
+
+| Tag | Description |
+| --- | --- |
+| [`<pc-camera>`](pc-camera) | Defines a camera that is used to render the scene. |
+| [`<pc-light>`](pc-light) | Defines a directional, omni or spot light, with optional shadows. |
+| [`<pc-render>`](pc-render) | Defines a render component that draws a primitive shape with a material. |
+| [`<pc-gsplat>`](pc-gsplat) | Defines a gsplat component that renders 3D Gaussian Splats. |
+| [`<pc-particle-system>`](pc-particle-system) | Defines a particle system driven by a JSON configuration asset. |
+| [`<pc-sky>`](pc-sky) | Defines an image-based skybox. |
+
+### Animation
+
+| Tag | Description |
+| --- | --- |
+| [`<pc-anim>`](pc-anim) | Defines an animation component that plays animation clips. |
+| [`<pc-anim-clip>`](pc-anim-clip) | Defines a single clip assigned to an animation component. |
+
+### Physics
+
+Physics needs the Ammo module, declared with [`<pc-wasm>`](pc-wasm).
+
+| Tag | Description |
+| --- | --- |
+| [`<pc-collision>`](pc-collision) | Defines a collision component used by triggers and rigid bodies. |
+| [`<pc-rigid-body>`](pc-rigid-body) | Defines a static, dynamic or kinematic rigid body. |
+| [`<pc-joint>`](pc-joint) | Defines a physics joint constraining two rigid bodies. |
+
+### User Interface
+
+A [`<pc-screen>`](pc-screen) hosts a tree of entities that each carry a [`<pc-element>`](pc-element); the other tags refine how those elements behave.
+
+| Tag | Description |
+| --- | --- |
+| [`<pc-screen>`](pc-screen) | Defines a screen component that can render element components. |
+| [`<pc-element>`](pc-element) | Defines a text, image or group user interface element. |
+| [`<pc-button>`](pc-button) | Defines a button component with hover, pressed and inactive states. |
+| [`<pc-layout-group>`](pc-layout-group) | Defines a layout group that arranges child elements in rows or columns. |
+| [`<pc-layout-child>`](pc-layout-child) | Defines per-child sizing rules within a layout group. |
+| [`<pc-scroll-view>`](pc-scroll-view) | Defines a scrollable viewport over a content entity. |
+| [`<pc-scrollbar>`](pc-scrollbar) | Defines a draggable scrollbar that drives a scroll view. |
+
+### Audio
+
+| Tag | Description |
+| --- | --- |
+| [`<pc-sound>`](pc-sound) | Defines a sound component that holds sound slots. |
+| [`<pc-sound-slot>`](pc-sound-slot) | Defines a single sound assigned to a sound component. |
+| [`<pc-audio-listener>`](pc-audio-listener) | Defines the point from which positional sound is heard. |
+
+### Scripting
+
+| Tag | Description |
+| --- | --- |
+| [`<pc-script>`](pc-script) | Defines a script component that hosts script instances. |
+| [`<pc-script-instance>`](pc-script-instance) | Defines a single script assigned to a script component. |
+
+## Shared Conventions
+
+The attributes of every tag share the same value conventions: an absent (or removed) attribute means the engine default applies, and an invalid value logs a console warning and falls back to the default. The *Type* column of each attribute table names how a value is written — Boolean, Number, Enum, Vector, Color, String, or a reference to an asset, a material or an entity — and [Attributes](../attributes.md) defines every one of those types.
 
 :::note[A component tag spells the engine component it adds]
 
-Drop the `pc-` prefix, drop the hyphens, and you have the engine's component id: `<pc-layout-group>` adds `entity.layoutgroup`, `<pc-rigid-body>` adds `entity.rigidbody`, `<pc-audio-listener>` adds `entity.audiolistener`. The rule holds in both directions for every component tag below, so neither spelling has to be memorized. The engine's ids run their words together only because they are JavaScript property names, which cannot carry a hyphen — an HTML tag can.
+Drop the `pc-` prefix, drop the hyphens, and you have the engine's component id: `<pc-layout-group>` adds `entity.layoutgroup`, `<pc-rigid-body>` adds `entity.rigidbody`, `<pc-audio-listener>` adds `entity.audiolistener`. The rule holds in both directions for every component tag on this page, so neither spelling has to be memorized. The engine's ids run their words together only because they are JavaScript property names, which cannot carry a hyphen — an HTML tag can.
 
 :::
 
@@ -21,36 +139,6 @@ A repeatable child takes its parent's tag as a prefix: [`<pc-anim-clip>`](pc-ani
 
 Every tag except [`<pc-material>`](pc-material) initializes asynchronously and fires a `ready` event once it has — see [The `ready` Event](../programmatic-access.md#the-ready-event) for the timing, and for the `whenReady()` helper that wraps it. The Events section on a tag's page lists only the events specific to that tag.
 
-| Tag | Description |
-| --- | --- |
-| [`<pc-anim>`](pc-anim) | Defines an animation component that plays animation clips. |
-| [`<pc-anim-clip>`](pc-anim-clip) | Defines a single clip assigned to an animation component. |
-| [`<pc-app>`](pc-app) | Defines the root element of your application. |
-| [`<pc-asset>`](pc-asset) | Defines an asset to be loaded by your application. |
-| [`<pc-audio-listener>`](pc-audio-listener) | Defines an audio listener component. |
-| [`<pc-button>`](pc-button) | Defines a button component. |
-| [`<pc-camera>`](pc-camera) | Defines a camera that is used to render the scene. |
-| [`<pc-collision>`](pc-collision) | Defines a collision component used by triggers and rigid bodies. |
-| [`<pc-element>`](pc-element) | Defines a text, image or group user interface element. |
-| [`<pc-entity>`](pc-entity) | Defines an entity. |
-| [`<pc-gsplat>`](pc-gsplat) | Defines a gsplat component that renders 3D Gaussian Splats. |
-| [`<pc-joint>`](pc-joint) | Defines a physics joint constraining two rigid bodies. |
-| [`<pc-layout-child>`](pc-layout-child) | Defines a layout child component. |
-| [`<pc-layout-group>`](pc-layout-group) | Defines a layout group component. |
-| [`<pc-light>`](pc-light) | Defines a light component. |
-| [`<pc-material>`](pc-material) | Defines a material that render components can reference. |
-| [`<pc-model>`](pc-model) | Defines an entity that instantiates a 3D model from a GLB file. |
-| [`<pc-node>`](pc-node) | Binds to a node inside a loaded model to override it. |
-| [`<pc-particle-system>`](pc-particle-system) | Defines a particle system component. |
-| [`<pc-render>`](pc-render) | Defines a render component. |
-| [`<pc-rigid-body>`](pc-rigid-body) | Defines a rigid body component. |
-| [`<pc-scene>`](pc-scene) | Defines a scene. |
-| [`<pc-screen>`](pc-screen) | Defines a screen component that can render element components. |
-| [`<pc-script>`](pc-script) | Defines a script component. |
-| [`<pc-script-instance>`](pc-script-instance) | Defines a single script assigned to a script component. |
-| [`<pc-scrollbar>`](pc-scrollbar) | Defines a scrollbar component. |
-| [`<pc-scroll-view>`](pc-scroll-view) | Defines a scroll view component. |
-| [`<pc-sky>`](pc-sky) | Defines an image-based skybox. |
-| [`<pc-sound>`](pc-sound) | Defines a sound component. |
-| [`<pc-sound-slot>`](pc-sound-slot) | Defines a single sound assigned to a sound component. |
-| [`<pc-wasm>`](pc-wasm) | Defines a WebAssembly module. |
+## All Tags A–Z {#all-tags-a-z}
+
+[`<pc-anim>`](pc-anim) · [`<pc-anim-clip>`](pc-anim-clip) · [`<pc-app>`](pc-app) · [`<pc-asset>`](pc-asset) · [`<pc-audio-listener>`](pc-audio-listener) · [`<pc-button>`](pc-button) · [`<pc-camera>`](pc-camera) · [`<pc-collision>`](pc-collision) · [`<pc-element>`](pc-element) · [`<pc-entity>`](pc-entity) · [`<pc-gsplat>`](pc-gsplat) · [`<pc-joint>`](pc-joint) · [`<pc-layout-child>`](pc-layout-child) · [`<pc-layout-group>`](pc-layout-group) · [`<pc-light>`](pc-light) · [`<pc-material>`](pc-material) · [`<pc-model>`](pc-model) · [`<pc-node>`](pc-node) · [`<pc-particle-system>`](pc-particle-system) · [`<pc-render>`](pc-render) · [`<pc-rigid-body>`](pc-rigid-body) · [`<pc-scene>`](pc-scene) · [`<pc-screen>`](pc-screen) · [`<pc-script>`](pc-script) · [`<pc-script-instance>`](pc-script-instance) · [`<pc-scrollbar>`](pc-scrollbar) · [`<pc-scroll-view>`](pc-scroll-view) · [`<pc-sky>`](pc-sky) · [`<pc-sound>`](pc-sound) · [`<pc-sound-slot>`](pc-sound-slot) · [`<pc-wasm>`](pc-wasm)

--- a/docs/user-manual/web-components/tags/pc-anim-clip.md
+++ b/docs/user-manual/web-components/tags/pc-anim-clip.md
@@ -56,7 +56,7 @@ The tracks bind to scene nodes by name, so a clip from a separate file animates 
 
 | Attribute | Type | Default | Description |
 | --- | --- | --- | --- |
-| `asset` | Asset ID | - | ID of the [`<pc-asset>`](../pc-asset) supplying the track — a `container`, an `animation` GLB or an `animclip` JSON. Empty takes it from the enclosing [`<pc-model>`](../pc-model) |
+| `asset` | [Asset ID](../attributes.md#asset-and-material-ids) | - | ID of the [`<pc-asset>`](../pc-asset) supplying the track — a `container`, an `animation` GLB or an `animclip` JSON. Empty takes it from the enclosing [`<pc-model>`](../pc-model) |
 | `loop` | Boolean | `"true"` | Whether the clip loops. A non-looping clip holds its last pose when it ends |
 | `name` | String | - | The clip's name, and the track looked up in its source. Unique within the component, and no `.` |
 | `speed` | Number | `"1"` | Playback speed of this clip, where negative values play it backwards |

--- a/docs/user-manual/web-components/tags/pc-anim-clip.md
+++ b/docs/user-manual/web-components/tags/pc-anim-clip.md
@@ -56,7 +56,7 @@ The tracks bind to scene nodes by name, so a clip from a separate file animates 
 
 | Attribute | Type | Default | Description |
 | --- | --- | --- | --- |
-| `asset` | String | - | ID of the [`<pc-asset>`](../pc-asset) supplying the track — a `container`, an `animation` GLB or an `animclip` JSON. Empty takes it from the enclosing [`<pc-model>`](../pc-model) |
+| `asset` | Asset ID | - | ID of the [`<pc-asset>`](../pc-asset) supplying the track — a `container`, an `animation` GLB or an `animclip` JSON. Empty takes it from the enclosing [`<pc-model>`](../pc-model) |
 | `loop` | Boolean | `"true"` | Whether the clip loops. A non-looping clip holds its last pose when it ends |
 | `name` | String | - | The clip's name, and the track looked up in its source. Unique within the component, and no `.` |
 | `speed` | Number | `"1"` | Playback speed of this clip, where negative values play it backwards |

--- a/docs/user-manual/web-components/tags/pc-asset.md
+++ b/docs/user-manual/web-components/tags/pc-asset.md
@@ -20,7 +20,7 @@ The `<pc-asset>` tag is used to define an asset.
 | `address-u` | Enum | `"repeat"` | For `texture` and `textureatlas` assets: how coordinates outside 0 to 1 sample horizontally — `"repeat"` \| `"clamp"` \| `"mirror"` |
 | `address-v` | Enum | `"repeat"` | For `texture` and `textureatlas` assets: how coordinates outside 0 to 1 sample vertically — `"repeat"` \| `"clamp"` \| `"mirror"` |
 | `anisotropy` | Number | `"1"` | For `texture` and `textureatlas` assets: maximum anisotropic filtering level, which improves quality at oblique viewing angles |
-| `atlas` | String | - | For `sprite` assets: the `id` of the `textureatlas` `<pc-asset>` this sprite reads from. The atlas must be declared before the sprite |
+| `atlas` | Asset ID | - | For `sprite` assets: the `id` of the `textureatlas` `<pc-asset>` this sprite reads from. The atlas must be declared before the sprite |
 | `data` | String | - | Inline JSON asset data. Used by texture atlases (frame definitions) and sprites |
 | `flip-y` | Boolean | `"false"` | For `texture` and `textureatlas` assets: whether the image data is flipped vertically at upload |
 | `frame-keys` | String | - | For `sprite` assets: space- or comma-separated list of atlas frame keys that make up the sprite |

--- a/docs/user-manual/web-components/tags/pc-asset.md
+++ b/docs/user-manual/web-components/tags/pc-asset.md
@@ -20,7 +20,7 @@ The `<pc-asset>` tag is used to define an asset.
 | `address-u` | Enum | `"repeat"` | For `texture` and `textureatlas` assets: how coordinates outside 0 to 1 sample horizontally — `"repeat"` \| `"clamp"` \| `"mirror"` |
 | `address-v` | Enum | `"repeat"` | For `texture` and `textureatlas` assets: how coordinates outside 0 to 1 sample vertically — `"repeat"` \| `"clamp"` \| `"mirror"` |
 | `anisotropy` | Number | `"1"` | For `texture` and `textureatlas` assets: maximum anisotropic filtering level, which improves quality at oblique viewing angles |
-| `atlas` | Asset ID | - | For `sprite` assets: the `id` of the `textureatlas` `<pc-asset>` this sprite reads from. The atlas must be declared before the sprite |
+| `atlas` | [Asset ID](../attributes.md#asset-and-material-ids) | - | For `sprite` assets: the `id` of the `textureatlas` `<pc-asset>` this sprite reads from. The atlas must be declared before the sprite |
 | `data` | String | - | Inline JSON asset data. Used by texture atlases (frame definitions) and sprites |
 | `flip-y` | Boolean | `"false"` | For `texture` and `textureatlas` assets: whether the image data is flipped vertically at upload |
 | `frame-keys` | String | - | For `sprite` assets: space- or comma-separated list of atlas frame keys that make up the sprite |

--- a/docs/user-manual/web-components/tags/pc-button.md
+++ b/docs/user-manual/web-components/tags/pc-button.md
@@ -22,14 +22,14 @@ The `<pc-button>` tag is used to define a button component, which makes an eleme
 | `enabled` | Boolean | `"true"` | Enabled state of the component |
 | `fade-duration` | Number | `"0"` | Duration in milliseconds over which tint transitions are applied |
 | `hit-padding` | Vector4 | `"0 0 0 0"` | Expands the button's hit area as `left bottom right top` |
-| `hover-sprite-asset` | String | - | Sprite [`<pc-asset>`](../pc-asset) id shown on hover (sprite transition mode) |
+| `hover-sprite-asset` | Asset ID | - | Sprite [`<pc-asset>`](../pc-asset) id shown on hover (sprite transition mode) |
 | `hover-sprite-frame` | Number | `"0"` | Frame of the hover sprite |
 | `hover-tint` | Color | `"1 1 1 1"` | Tint applied to the image entity on hover (tint transition mode) |
-| `image` | String | - | [Reference](../attributes.md#entity-references) (entity `name`, or document-wide `#` selector) to the [`<pc-entity>`](../pc-entity) whose image element shows transitions. Defaults to the button's own entity — inside a [`<pc-model>`](../pc-model) that is the model's host, so name a UI entity explicitly there |
-| `inactive-sprite-asset` | String | - | Sprite [`<pc-asset>`](../pc-asset) id shown when inactive (sprite transition mode) |
+| `image` | Entity Reference | - | [Reference](../attributes.md#entity-references) (entity `name`, or document-wide `#` selector) to the [`<pc-entity>`](../pc-entity) whose image element shows transitions. Defaults to the button's own entity — inside a [`<pc-model>`](../pc-model) that is the model's host, so name a UI entity explicitly there |
+| `inactive-sprite-asset` | Asset ID | - | Sprite [`<pc-asset>`](../pc-asset) id shown when inactive (sprite transition mode) |
 | `inactive-sprite-frame` | Number | `"0"` | Frame of the inactive sprite |
 | `inactive-tint` | Color | `"1 1 1 1"` | Tint applied to the image entity when inactive (tint transition mode) |
-| `pressed-sprite-asset` | String | - | Sprite [`<pc-asset>`](../pc-asset) id shown when pressed (sprite transition mode) |
+| `pressed-sprite-asset` | Asset ID | - | Sprite [`<pc-asset>`](../pc-asset) id shown when pressed (sprite transition mode) |
 | `pressed-sprite-frame` | Number | `"0"` | Frame of the pressed sprite |
 | `pressed-tint` | Color | `"1 1 1 1"` | Tint applied to the image entity when pressed (tint transition mode) |
 | `transition-mode` | Enum | `"tint"` | How the button reacts to hover/press: `"tint"` \| `"sprite"` |

--- a/docs/user-manual/web-components/tags/pc-button.md
+++ b/docs/user-manual/web-components/tags/pc-button.md
@@ -22,14 +22,14 @@ The `<pc-button>` tag is used to define a button component, which makes an eleme
 | `enabled` | Boolean | `"true"` | Enabled state of the component |
 | `fade-duration` | Number | `"0"` | Duration in milliseconds over which tint transitions are applied |
 | `hit-padding` | Vector4 | `"0 0 0 0"` | Expands the button's hit area as `left bottom right top` |
-| `hover-sprite-asset` | Asset ID | - | Sprite [`<pc-asset>`](../pc-asset) id shown on hover (sprite transition mode) |
+| `hover-sprite-asset` | [Asset ID](../attributes.md#asset-and-material-ids) | - | Sprite [`<pc-asset>`](../pc-asset) id shown on hover (sprite transition mode) |
 | `hover-sprite-frame` | Number | `"0"` | Frame of the hover sprite |
 | `hover-tint` | Color | `"1 1 1 1"` | Tint applied to the image entity on hover (tint transition mode) |
-| `image` | Entity Reference | - | [Reference](../attributes.md#entity-references) (entity `name`, or document-wide `#` selector) to the [`<pc-entity>`](../pc-entity) whose image element shows transitions. Defaults to the button's own entity — inside a [`<pc-model>`](../pc-model) that is the model's host, so name a UI entity explicitly there |
-| `inactive-sprite-asset` | Asset ID | - | Sprite [`<pc-asset>`](../pc-asset) id shown when inactive (sprite transition mode) |
+| `image` | [Entity Reference](../attributes.md#entity-references) | - | The [`<pc-entity>`](../pc-entity) whose image element shows transitions. Defaults to the button's own entity — inside a [`<pc-model>`](../pc-model) that is the model's host, so name a UI entity explicitly there |
+| `inactive-sprite-asset` | [Asset ID](../attributes.md#asset-and-material-ids) | - | Sprite [`<pc-asset>`](../pc-asset) id shown when inactive (sprite transition mode) |
 | `inactive-sprite-frame` | Number | `"0"` | Frame of the inactive sprite |
 | `inactive-tint` | Color | `"1 1 1 1"` | Tint applied to the image entity when inactive (tint transition mode) |
-| `pressed-sprite-asset` | Asset ID | - | Sprite [`<pc-asset>`](../pc-asset) id shown when pressed (sprite transition mode) |
+| `pressed-sprite-asset` | [Asset ID](../attributes.md#asset-and-material-ids) | - | Sprite [`<pc-asset>`](../pc-asset) id shown when pressed (sprite transition mode) |
 | `pressed-sprite-frame` | Number | `"0"` | Frame of the pressed sprite |
 | `pressed-tint` | Color | `"1 1 1 1"` | Tint applied to the image entity when pressed (tint transition mode) |
 | `transition-mode` | Enum | `"tint"` | How the button reacts to hover/press: `"tint"` \| `"sprite"` |

--- a/docs/user-manual/web-components/tags/pc-element.md
+++ b/docs/user-manual/web-components/tags/pc-element.md
@@ -33,7 +33,7 @@ Image elements can render a sprite (including 9-sliced sprites, via a `sliced` [
 | `color` | Color | `"1 1 1 1"` | Color as space-separated RGBA values, hex code, or [named color](https://github.com/playcanvas/web-components/blob/main/src/colors.ts) |
 | `enable-markup` | Boolean | `"false"` | Enables markup processing for styled text. Supports tags like `[color="#ff0000"]text[/color]` for colored text. |
 | `enabled` | Boolean | `"true"` | Enabled state of the component |
-| `font-asset` | Asset ID | - | Font [`<pc-asset>`](../pc-asset) ID (must reference a `font` type asset). Required for text elements only |
+| `font-asset` | [Asset ID](../attributes.md#asset-and-material-ids) | - | Font [`<pc-asset>`](../pc-asset) ID (must reference a `font` type asset). Required for text elements only |
 | `font-size` | Number | `"32"` | Font size in pixels |
 | `height` | Number | `"0"` | Height in pixels (0 for auto-sizing) |
 | `line-height` | Number | `"32"` | Line height in pixels |
@@ -44,10 +44,10 @@ Image elements can render a sprite (including 9-sliced sprites, via a `sliced` [
 | `opacity` | Number | `"1"` | Opacity, from 0 (transparent) to 1 (opaque) |
 | `pivot` | Vector2 | `"0.5 0.5"` | Pivot point as "X Y" values |
 | `pixels-per-unit` | Number | - | Pixels per unit used when rendering a sprite. Image elements only |
-| `sprite-asset` | Asset ID | - | Sprite [`<pc-asset>`](../pc-asset) ID to render. Image elements only |
+| `sprite-asset` | [Asset ID](../attributes.md#asset-and-material-ids) | - | Sprite [`<pc-asset>`](../pc-asset) ID to render. Image elements only |
 | `sprite-frame` | Number | `"0"` | Frame index of the sprite to render. Image elements only |
 | `text` | String | - | Text content to display |
-| `texture-asset` | Asset ID | - | Texture [`<pc-asset>`](../pc-asset) ID to render. Image elements only |
+| `texture-asset` | [Asset ID](../attributes.md#asset-and-material-ids) | - | Texture [`<pc-asset>`](../pc-asset) ID to render. Image elements only |
 | `type` | Enum | `"group"` | Element type: `"group"` \| `"image"` \| `"text"` |
 | `use-input` | Boolean | `"false"` | Whether the element receives pointer input. Required for [`<pc-button>`](../pc-button) and scroll-view interaction |
 | `width` | Number | `"0"` | Width in pixels (0 for auto-sizing) |

--- a/docs/user-manual/web-components/tags/pc-element.md
+++ b/docs/user-manual/web-components/tags/pc-element.md
@@ -33,7 +33,7 @@ Image elements can render a sprite (including 9-sliced sprites, via a `sliced` [
 | `color` | Color | `"1 1 1 1"` | Color as space-separated RGBA values, hex code, or [named color](https://github.com/playcanvas/web-components/blob/main/src/colors.ts) |
 | `enable-markup` | Boolean | `"false"` | Enables markup processing for styled text. Supports tags like `[color="#ff0000"]text[/color]` for colored text. |
 | `enabled` | Boolean | `"true"` | Enabled state of the component |
-| `font-asset` | String | - | Font [`<pc-asset>`](../pc-asset) ID (must reference a `font` type asset). Required for text elements only |
+| `font-asset` | Asset ID | - | Font [`<pc-asset>`](../pc-asset) ID (must reference a `font` type asset). Required for text elements only |
 | `font-size` | Number | `"32"` | Font size in pixels |
 | `height` | Number | `"0"` | Height in pixels (0 for auto-sizing) |
 | `line-height` | Number | `"32"` | Line height in pixels |
@@ -44,10 +44,10 @@ Image elements can render a sprite (including 9-sliced sprites, via a `sliced` [
 | `opacity` | Number | `"1"` | Opacity, from 0 (transparent) to 1 (opaque) |
 | `pivot` | Vector2 | `"0.5 0.5"` | Pivot point as "X Y" values |
 | `pixels-per-unit` | Number | - | Pixels per unit used when rendering a sprite. Image elements only |
-| `sprite-asset` | String | - | Sprite [`<pc-asset>`](../pc-asset) ID to render. Image elements only |
+| `sprite-asset` | Asset ID | - | Sprite [`<pc-asset>`](../pc-asset) ID to render. Image elements only |
 | `sprite-frame` | Number | `"0"` | Frame index of the sprite to render. Image elements only |
 | `text` | String | - | Text content to display |
-| `texture-asset` | String | - | Texture [`<pc-asset>`](../pc-asset) ID to render. Image elements only |
+| `texture-asset` | Asset ID | - | Texture [`<pc-asset>`](../pc-asset) ID to render. Image elements only |
 | `type` | Enum | `"group"` | Element type: `"group"` \| `"image"` \| `"text"` |
 | `use-input` | Boolean | `"false"` | Whether the element receives pointer input. Required for [`<pc-button>`](../pc-button) and scroll-view interaction |
 | `width` | Number | `"0"` | Width in pixels (0 for auto-sizing) |

--- a/docs/user-manual/web-components/tags/pc-gsplat.md
+++ b/docs/user-manual/web-components/tags/pc-gsplat.md
@@ -19,7 +19,7 @@ When rendering splat-based scenes, it is recommended to set `antialias` to `fals
 
 | Attribute | Type | Default | Description |
 | --- | --- | --- | --- |
-| `asset` | Asset ID | - | Gaussian splat asset ID (must reference a `gsplat` type asset) |
+| `asset` | [Asset ID](../attributes.md#asset-and-material-ids) | - | Gaussian splat asset ID (must reference a `gsplat` type asset) |
 | `cast-shadows` | Boolean | `"false"` | Whether the gsplat component casts shadows |
 | `enabled` | Boolean | `"true"` | Enabled state of the component |
 | `lod-base-distance` | Number | `"5"` | Distance for the first LOD transition (LOD 0 to LOD 1). Splats closer than this use the highest-quality LOD. Minimum `0.1`. Only affects assets that contain LOD levels. |

--- a/docs/user-manual/web-components/tags/pc-gsplat.md
+++ b/docs/user-manual/web-components/tags/pc-gsplat.md
@@ -19,7 +19,7 @@ When rendering splat-based scenes, it is recommended to set `antialias` to `fals
 
 | Attribute | Type | Default | Description |
 | --- | --- | --- | --- |
-| `asset` | String | - | Gaussian splat asset ID (must reference a `gsplat` type asset) |
+| `asset` | Asset ID | - | Gaussian splat asset ID (must reference a `gsplat` type asset) |
 | `cast-shadows` | Boolean | `"false"` | Whether the gsplat component casts shadows |
 | `enabled` | Boolean | `"true"` | Enabled state of the component |
 | `lod-base-distance` | Number | `"5"` | Distance for the first LOD transition (LOD 0 to LOD 1). Splats closer than this use the highest-quality LOD. Minimum `0.1`. Only affects assets that contain LOD levels. |

--- a/docs/user-manual/web-components/tags/pc-joint.md
+++ b/docs/user-manual/web-components/tags/pc-joint.md
@@ -60,8 +60,8 @@ The engine's joint component is in alpha, so its behavior and API may change. Ex
 | `enable-collision` | Boolean | `"false"` | Whether the two constrained bodies collide with each other |
 | `enable-limits` | Boolean | `"false"` | Whether the joint's limits are enforced. Limit attributes do nothing until this is set |
 | `enabled` | Boolean | `"true"` | Enabled state of the component |
-| `entity-a` | Entity Reference | - | Reference to the [`<pc-entity>`](../pc-entity) providing the first body. Needs a [`<pc-rigid-body>`](../pc-rigid-body) |
-| `entity-b` | Entity Reference | - | Reference to the [`<pc-entity>`](../pc-entity) providing the second body. Leave empty to constrain `entity-a` to a fixed point in world space |
+| `entity-a` | [Entity Reference](../attributes.md#entity-references) | - | Reference to the [`<pc-entity>`](../pc-entity) providing the first body. Needs a [`<pc-rigid-body>`](../pc-rigid-body) |
+| `entity-b` | [Entity Reference](../attributes.md#entity-references) | - | Reference to the [`<pc-entity>`](../pc-entity) providing the second body. Leave empty to constrain `entity-a` to a fixed point in world space |
 | `limits` | Vector2 | `"-45 45"` | Rotation or travel limits about the primary axis, as "min max" — degrees for `hinge`, units for `slider` |
 | `linear-damping` | Vector3 | `"1 1 1"` | Spring damping per linear axis. Used by `6dof` |
 | `linear-equilibrium` | Vector3 | `"0 0 0"` | Rest point of the linear springs. Used by `6dof` |

--- a/docs/user-manual/web-components/tags/pc-joint.md
+++ b/docs/user-manual/web-components/tags/pc-joint.md
@@ -60,8 +60,8 @@ The engine's joint component is in alpha, so its behavior and API may change. Ex
 | `enable-collision` | Boolean | `"false"` | Whether the two constrained bodies collide with each other |
 | `enable-limits` | Boolean | `"false"` | Whether the joint's limits are enforced. Limit attributes do nothing until this is set |
 | `enabled` | Boolean | `"true"` | Enabled state of the component |
-| `entity-a` | String | - | Reference to the [`<pc-entity>`](../pc-entity) providing the first body. Needs a [`<pc-rigid-body>`](../pc-rigid-body) |
-| `entity-b` | String | - | Reference to the [`<pc-entity>`](../pc-entity) providing the second body. Leave empty to constrain `entity-a` to a fixed point in world space |
+| `entity-a` | Entity Reference | - | Reference to the [`<pc-entity>`](../pc-entity) providing the first body. Needs a [`<pc-rigid-body>`](../pc-rigid-body) |
+| `entity-b` | Entity Reference | - | Reference to the [`<pc-entity>`](../pc-entity) providing the second body. Leave empty to constrain `entity-a` to a fixed point in world space |
 | `limits` | Vector2 | `"-45 45"` | Rotation or travel limits about the primary axis, as "min max" — degrees for `hinge`, units for `slider` |
 | `linear-damping` | Vector3 | `"1 1 1"` | Spring damping per linear axis. Used by `6dof` |
 | `linear-equilibrium` | Vector3 | `"0 0 0"` | Rest point of the linear springs. Used by `6dof` |

--- a/docs/user-manual/web-components/tags/pc-material.md
+++ b/docs/user-manual/web-components/tags/pc-material.md
@@ -28,7 +28,7 @@ The `roughness` and `roughness-map` attributes are aliases for `gloss` and `glos
 | `alpha-test` | Number | `"0"` | Alpha test reference value. Fragments with an opacity below this value are discarded |
 | `alpha-to-coverage` | Boolean | `"false"` | Whether to use alpha-to-coverage, which resolves transparency using multisampling |
 | `ao-intensity` | Number | `"1"` | Strength of the ambient occlusion map, from 0 to 1 |
-| `ao-map` | Asset ID | - | `id` of a texture [`<pc-asset>`](../pc-asset) used as the ambient occlusion map |
+| `ao-map` | [Asset ID](../attributes.md#asset-and-material-ids) | - | `id` of a texture [`<pc-asset>`](../pc-asset) used as the ambient occlusion map |
 | `blend-type` | Enum | `"none"` | How the material is blended with the scene behind it: `"none"` \| `"normal"` \| `"additive"` \| `"additive-alpha"` \| `"premultiplied"` \| `"multiplicative"` \| `"multiplicative-2x"` \| `"screen"` \| `"min"` \| `"max"` \| `"subtractive"` |
 | `bumpiness` | Number | `"1"` | Strength of the normal map, where 0 is flat and 1 is the map's full effect |
 | `cull` | Enum | `"back"` | Which faces of a mesh are culled: `"none"` \| `"back"` \| `"front"` \| `"front-and-back"` |
@@ -36,30 +36,30 @@ The `roughness` and `roughness-map` attributes are aliases for `gloss` and `glos
 | `depth-test` | Boolean | `"true"` | Whether fragments are tested against the depth buffer |
 | `depth-write` | Boolean | `"true"` | Whether fragments write to the depth buffer |
 | `diffuse` | Color | `"1 1 1"` | Diffuse color of the material |
-| `diffuse-map` | Asset ID | - | `id` of a texture [`<pc-asset>`](../pc-asset) used as the diffuse map |
+| `diffuse-map` | [Asset ID](../attributes.md#asset-and-material-ids) | - | `id` of a texture [`<pc-asset>`](../pc-asset) used as the diffuse map |
 | `emissive` | Color | `"0 0 0"` | Emissive color of the material |
 | `emissive-intensity` | Number | `"1"` | Multiplier applied to the emissive color and map |
-| `emissive-map` | Asset ID | - | `id` of a texture [`<pc-asset>`](../pc-asset) used as the emissive map |
+| `emissive-map` | [Asset ID](../attributes.md#asset-and-material-ids) | - | `id` of a texture [`<pc-asset>`](../pc-asset) used as the emissive map |
 | `enable-ggx-specular` | Boolean | `"false"` | Whether to use the GGX specular model, which supports anisotropy |
 | `fresnel-model` | Enum | `"schlick"` | Fresnel model used for specular reflections at grazing angles: `"none"` \| `"schlick"` |
 | `gloss` | Number | `"0.25"` | Glossiness of the material, from 0 (rough) to 1 (shiny). See `roughness` |
 | `gloss-invert` | Boolean | `"false"` | Whether the gloss value and map are inverted, making the material treat them as roughness. Setting `roughness` or `roughness-map` enables this automatically |
-| `gloss-map` | Asset ID | - | `id` of a texture [`<pc-asset>`](../pc-asset) used as the gloss map |
-| `height-map` | Asset ID | - | `id` of a texture [`<pc-asset>`](../pc-asset) used as the height map |
+| `gloss-map` | [Asset ID](../attributes.md#asset-and-material-ids) | - | `id` of a texture [`<pc-asset>`](../pc-asset) used as the gloss map |
+| `height-map` | [Asset ID](../attributes.md#asset-and-material-ids) | - | `id` of a texture [`<pc-asset>`](../pc-asset) used as the height map |
 | `height-map-factor` | Number | `"1"` | Strength of the parallax effect driven by the height map |
 | `id` | String | - | Unique identifier used by other tags to reference this material |
 | `metalness` | Number | `"0"` | How metallic the surface is, from 0 (dielectric) to 1 (metal) |
-| `metalness-map` | Asset ID | - | `id` of a texture [`<pc-asset>`](../pc-asset) used as the metalness map |
+| `metalness-map` | [Asset ID](../attributes.md#asset-and-material-ids) | - | `id` of a texture [`<pc-asset>`](../pc-asset) used as the metalness map |
 | `name` | String | `"Untitled"` | Name of the material. A label, not a reference: other tags always address the material by `id` |
-| `normal-map` | Asset ID | - | `id` of a texture [`<pc-asset>`](../pc-asset) used as the normal map |
+| `normal-map` | [Asset ID](../attributes.md#asset-and-material-ids) | - | `id` of a texture [`<pc-asset>`](../pc-asset) used as the normal map |
 | `occlude-direct` | Boolean | `"false"` | Whether ambient occlusion also attenuates direct lighting |
 | `occlude-specular` | Enum | `"ao"` | How specular reflections are occluded: `"none"` \| `"ao"` \| `"gloss-dependent"` |
 | `opacity` | Number | `"1"` | Opacity of the material, from 0 (transparent) to 1 (opaque). Requires a `blend-type` other than `"none"` to have a visible effect |
 | `opacity-dither` | Enum | `"none"` | Dithering used to render opacity, which approximates transparency without blending: `"none"` \| `"bayer8"` \| `"bluenoise"` \| `"ignnoise"` |
 | `opacity-fades-specular` | Boolean | `"true"` | Whether specular highlights fade out as the material becomes transparent |
-| `opacity-map` | Asset ID | - | `id` of a texture [`<pc-asset>`](../pc-asset) used as the opacity map |
+| `opacity-map` | [Asset ID](../attributes.md#asset-and-material-ids) | - | `id` of a texture [`<pc-asset>`](../pc-asset) used as the opacity map |
 | `roughness` | Number | - | Roughness of the material, from 0 (shiny) to 1 (rough). An alias for `gloss` that also sets `gloss-invert`, so do not combine it with the `gloss` attributes |
-| `roughness-map` | Asset ID | - | `id` of a texture [`<pc-asset>`](../pc-asset) used as the roughness map. An alias for `gloss-map` that also sets `gloss-invert`, so do not combine it with the `gloss` attributes |
+| `roughness-map` | [Asset ID](../attributes.md#asset-and-material-ids) | - | `id` of a texture [`<pc-asset>`](../pc-asset) used as the roughness map. An alias for `gloss-map` that also sets `gloss-invert`, so do not combine it with the `gloss` attributes |
 | `slope-depth-bias` | Number | `"0"` | Depth offset applied in proportion to a surface's slope, used to resolve z-fighting |
 | `specular` | Color | `"0 0 0"` | Specular color of the material. Applies only when the metalness workflow is disabled or `use-metalness-specular-color` is enabled |
 | `specularity-factor` | Number | `"1"` | Strength of specular reflections at direct angles, from 0 to 1. Applies only when `use-metalness-specular-color` is enabled |

--- a/docs/user-manual/web-components/tags/pc-material.md
+++ b/docs/user-manual/web-components/tags/pc-material.md
@@ -28,7 +28,7 @@ The `roughness` and `roughness-map` attributes are aliases for `gloss` and `glos
 | `alpha-test` | Number | `"0"` | Alpha test reference value. Fragments with an opacity below this value are discarded |
 | `alpha-to-coverage` | Boolean | `"false"` | Whether to use alpha-to-coverage, which resolves transparency using multisampling |
 | `ao-intensity` | Number | `"1"` | Strength of the ambient occlusion map, from 0 to 1 |
-| `ao-map` | String | - | `id` of a texture [`<pc-asset>`](../pc-asset) used as the ambient occlusion map |
+| `ao-map` | Asset ID | - | `id` of a texture [`<pc-asset>`](../pc-asset) used as the ambient occlusion map |
 | `blend-type` | Enum | `"none"` | How the material is blended with the scene behind it: `"none"` \| `"normal"` \| `"additive"` \| `"additive-alpha"` \| `"premultiplied"` \| `"multiplicative"` \| `"multiplicative-2x"` \| `"screen"` \| `"min"` \| `"max"` \| `"subtractive"` |
 | `bumpiness` | Number | `"1"` | Strength of the normal map, where 0 is flat and 1 is the map's full effect |
 | `cull` | Enum | `"back"` | Which faces of a mesh are culled: `"none"` \| `"back"` \| `"front"` \| `"front-and-back"` |
@@ -36,30 +36,30 @@ The `roughness` and `roughness-map` attributes are aliases for `gloss` and `glos
 | `depth-test` | Boolean | `"true"` | Whether fragments are tested against the depth buffer |
 | `depth-write` | Boolean | `"true"` | Whether fragments write to the depth buffer |
 | `diffuse` | Color | `"1 1 1"` | Diffuse color of the material |
-| `diffuse-map` | String | - | `id` of a texture [`<pc-asset>`](../pc-asset) used as the diffuse map |
+| `diffuse-map` | Asset ID | - | `id` of a texture [`<pc-asset>`](../pc-asset) used as the diffuse map |
 | `emissive` | Color | `"0 0 0"` | Emissive color of the material |
 | `emissive-intensity` | Number | `"1"` | Multiplier applied to the emissive color and map |
-| `emissive-map` | String | - | `id` of a texture [`<pc-asset>`](../pc-asset) used as the emissive map |
+| `emissive-map` | Asset ID | - | `id` of a texture [`<pc-asset>`](../pc-asset) used as the emissive map |
 | `enable-ggx-specular` | Boolean | `"false"` | Whether to use the GGX specular model, which supports anisotropy |
 | `fresnel-model` | Enum | `"schlick"` | Fresnel model used for specular reflections at grazing angles: `"none"` \| `"schlick"` |
 | `gloss` | Number | `"0.25"` | Glossiness of the material, from 0 (rough) to 1 (shiny). See `roughness` |
 | `gloss-invert` | Boolean | `"false"` | Whether the gloss value and map are inverted, making the material treat them as roughness. Setting `roughness` or `roughness-map` enables this automatically |
-| `gloss-map` | String | - | `id` of a texture [`<pc-asset>`](../pc-asset) used as the gloss map |
-| `height-map` | String | - | `id` of a texture [`<pc-asset>`](../pc-asset) used as the height map |
+| `gloss-map` | Asset ID | - | `id` of a texture [`<pc-asset>`](../pc-asset) used as the gloss map |
+| `height-map` | Asset ID | - | `id` of a texture [`<pc-asset>`](../pc-asset) used as the height map |
 | `height-map-factor` | Number | `"1"` | Strength of the parallax effect driven by the height map |
 | `id` | String | - | Unique identifier used by other tags to reference this material |
 | `metalness` | Number | `"0"` | How metallic the surface is, from 0 (dielectric) to 1 (metal) |
-| `metalness-map` | String | - | `id` of a texture [`<pc-asset>`](../pc-asset) used as the metalness map |
+| `metalness-map` | Asset ID | - | `id` of a texture [`<pc-asset>`](../pc-asset) used as the metalness map |
 | `name` | String | `"Untitled"` | Name of the material. A label, not a reference: other tags always address the material by `id` |
-| `normal-map` | String | - | `id` of a texture [`<pc-asset>`](../pc-asset) used as the normal map |
+| `normal-map` | Asset ID | - | `id` of a texture [`<pc-asset>`](../pc-asset) used as the normal map |
 | `occlude-direct` | Boolean | `"false"` | Whether ambient occlusion also attenuates direct lighting |
 | `occlude-specular` | Enum | `"ao"` | How specular reflections are occluded: `"none"` \| `"ao"` \| `"gloss-dependent"` |
 | `opacity` | Number | `"1"` | Opacity of the material, from 0 (transparent) to 1 (opaque). Requires a `blend-type` other than `"none"` to have a visible effect |
 | `opacity-dither` | Enum | `"none"` | Dithering used to render opacity, which approximates transparency without blending: `"none"` \| `"bayer8"` \| `"bluenoise"` \| `"ignnoise"` |
 | `opacity-fades-specular` | Boolean | `"true"` | Whether specular highlights fade out as the material becomes transparent |
-| `opacity-map` | String | - | `id` of a texture [`<pc-asset>`](../pc-asset) used as the opacity map |
+| `opacity-map` | Asset ID | - | `id` of a texture [`<pc-asset>`](../pc-asset) used as the opacity map |
 | `roughness` | Number | - | Roughness of the material, from 0 (shiny) to 1 (rough). An alias for `gloss` that also sets `gloss-invert`, so do not combine it with the `gloss` attributes |
-| `roughness-map` | String | - | `id` of a texture [`<pc-asset>`](../pc-asset) used as the roughness map. An alias for `gloss-map` that also sets `gloss-invert`, so do not combine it with the `gloss` attributes |
+| `roughness-map` | Asset ID | - | `id` of a texture [`<pc-asset>`](../pc-asset) used as the roughness map. An alias for `gloss-map` that also sets `gloss-invert`, so do not combine it with the `gloss` attributes |
 | `slope-depth-bias` | Number | `"0"` | Depth offset applied in proportion to a surface's slope, used to resolve z-fighting |
 | `specular` | Color | `"0 0 0"` | Specular color of the material. Applies only when the metalness workflow is disabled or `use-metalness-specular-color` is enabled |
 | `specularity-factor` | Number | `"1"` | Strength of specular reflections at direct angles, from 0 to 1. Applies only when `use-metalness-specular-color` is enabled |

--- a/docs/user-manual/web-components/tags/pc-model.md
+++ b/docs/user-manual/web-components/tags/pc-model.md
@@ -35,7 +35,7 @@ Because the element's own transform belongs to the host, `position`, `rotation` 
 
 | Attribute | Type | Default | Description |
 | --- | --- | --- | --- |
-| `asset` | Asset ID | - | Container asset ID (must reference a `container` type asset) |
+| `asset` | [Asset ID](../attributes.md#asset-and-material-ids) | - | Container asset ID (must reference a `container` type asset) |
 | `enabled` | Boolean | `"true"` | Enabled state of the model |
 | `name` | String | - | Name identifier for the host entity |
 | `position` | Vector3 | `"0 0 0"` | Local-space position as "X Y Z" values |

--- a/docs/user-manual/web-components/tags/pc-model.md
+++ b/docs/user-manual/web-components/tags/pc-model.md
@@ -35,7 +35,7 @@ Because the element's own transform belongs to the host, `position`, `rotation` 
 
 | Attribute | Type | Default | Description |
 | --- | --- | --- | --- |
-| `asset` | String | - | Container asset ID (must reference a `container` type asset) |
+| `asset` | Asset ID | - | Container asset ID (must reference a `container` type asset) |
 | `enabled` | Boolean | `"true"` | Enabled state of the model |
 | `name` | String | - | Name identifier for the host entity |
 | `position` | Vector3 | `"0 0 0"` | Local-space position as "X Y Z" values |

--- a/docs/user-manual/web-components/tags/pc-particle-system.md
+++ b/docs/user-manual/web-components/tags/pc-particle-system.md
@@ -17,7 +17,7 @@ The `<pc-particle-system>` tag is used to define a particle system.
 
 | Attribute | Type | Default | Description |
 | --- | --- | --- | --- |
-| `asset` | Asset ID | - | JSON asset ID defining the particle system configuration |
+| `asset` | [Asset ID](../attributes.md#asset-and-material-ids) | - | JSON asset ID defining the particle system configuration |
 | `enabled` | Boolean | `"true"` | Enabled state of the component |
 
 </div>

--- a/docs/user-manual/web-components/tags/pc-particle-system.md
+++ b/docs/user-manual/web-components/tags/pc-particle-system.md
@@ -17,7 +17,7 @@ The `<pc-particle-system>` tag is used to define a particle system.
 
 | Attribute | Type | Default | Description |
 | --- | --- | --- | --- |
-| `asset` | String | - | JSON asset ID defining the particle system configuration |
+| `asset` | Asset ID | - | JSON asset ID defining the particle system configuration |
 | `enabled` | Boolean | `"true"` | Enabled state of the component |
 
 </div>

--- a/docs/user-manual/web-components/tags/pc-render.md
+++ b/docs/user-manual/web-components/tags/pc-render.md
@@ -19,7 +19,7 @@ The `<pc-render>` tag is used to define a render component that renders a 3D pri
 | --- | --- | --- | --- |
 | `cast-shadows` | Boolean | `"true"` | Whether the component casts shadows |
 | `enabled` | Boolean | `"true"` | Enabled state of the component |
-| `material` | String | - | `id` of a [`<pc-material>`](../pc-material) to render the primitive with. If omitted, a default material is used |
+| `material` | Material ID | - | `id` of a [`<pc-material>`](../pc-material) to render the primitive with. If omitted, a default material is used |
 | `receive-shadows` | Boolean | `"true"` | Whether the component receives shadows |
 | `type` | Enum | `"box"` | Primitive shape to render: `"box"` \| `"capsule"` \| `"cone"` \| `"cylinder"` \| `"plane"` \| `"sphere"` |
 

--- a/docs/user-manual/web-components/tags/pc-render.md
+++ b/docs/user-manual/web-components/tags/pc-render.md
@@ -19,7 +19,7 @@ The `<pc-render>` tag is used to define a render component that renders a 3D pri
 | --- | --- | --- | --- |
 | `cast-shadows` | Boolean | `"true"` | Whether the component casts shadows |
 | `enabled` | Boolean | `"true"` | Enabled state of the component |
-| `material` | Material ID | - | `id` of a [`<pc-material>`](../pc-material) to render the primitive with. If omitted, a default material is used |
+| `material` | [Material ID](../attributes.md#asset-and-material-ids) | - | `id` of a [`<pc-material>`](../pc-material) to render the primitive with. If omitted, a default material is used |
 | `receive-shadows` | Boolean | `"true"` | Whether the component receives shadows |
 | `type` | Enum | `"box"` | Primitive shape to render: `"box"` \| `"capsule"` \| `"cone"` \| `"cylinder"` \| `"plane"` \| `"sphere"` |
 

--- a/docs/user-manual/web-components/tags/pc-scroll-view.md
+++ b/docs/user-manual/web-components/tags/pc-scroll-view.md
@@ -20,19 +20,19 @@ The `<pc-scroll-view>` tag is used to define a scroll view component, which lets
 | Attribute | Type | Default | Description |
 | --- | --- | --- | --- |
 | `bounce-amount` | Number | `"0.1"` | How far content bounces past its bounds when `scroll-mode="bounce"` (0 to 1) |
-| `content` | Entity Reference | - | Reference to the content [`<pc-entity>`](../pc-entity) that is moved as the view is scrolled |
+| `content` | [Entity Reference](../attributes.md#entity-references) | - | Reference to the content [`<pc-entity>`](../pc-entity) that is moved as the view is scrolled |
 | `enabled` | Boolean | `"true"` | Enabled state of the component |
 | `friction` | Number | `"0.05"` | How freely the content moves once thrown (0 = none, 1 = high) |
 | `horizontal` | Boolean | `"true"` | Whether scrolling along the horizontal axis is enabled |
-| `horizontal-scrollbar` | Entity Reference | - | Reference to the [`<pc-entity>`](../pc-entity) holding the horizontal [`<pc-scrollbar>`](../pc-scrollbar) |
+| `horizontal-scrollbar` | [Entity Reference](../attributes.md#entity-references) | - | Reference to the [`<pc-entity>`](../pc-entity) holding the horizontal [`<pc-scrollbar>`](../pc-scrollbar) |
 | `horizontal-scrollbar-visibility` | Enum | `"when-required"` | When the horizontal scrollbar is shown: `"always"` \| `"when-required"` |
 | `mouse-wheel-sensitivity` | Vector2 | `"1 1"` | Mouse wheel sensitivity as `x y` (0 on an axis disables wheel scrolling for it) |
 | `scroll-mode` | Enum | `"bounce"` | Behavior when scrolled past bounds: `"clamp"` \| `"bounce"` \| `"infinite"` |
 | `use-mouse-wheel` | Boolean | `"true"` | Whether the scroll view responds to the mouse wheel |
 | `vertical` | Boolean | `"true"` | Whether scrolling along the vertical axis is enabled |
-| `vertical-scrollbar` | Entity Reference | - | Reference to the [`<pc-entity>`](../pc-entity) holding the vertical [`<pc-scrollbar>`](../pc-scrollbar) |
+| `vertical-scrollbar` | [Entity Reference](../attributes.md#entity-references) | - | Reference to the [`<pc-entity>`](../pc-entity) holding the vertical [`<pc-scrollbar>`](../pc-scrollbar) |
 | `vertical-scrollbar-visibility` | Enum | `"when-required"` | When the vertical scrollbar is shown: `"always"` \| `"when-required"` |
-| `viewport` | Entity Reference | - | Reference to the [`<pc-entity>`](../pc-entity) used as the viewport, which clips the content to the scroll view's bounds |
+| `viewport` | [Entity Reference](../attributes.md#entity-references) | - | Reference to the [`<pc-entity>`](../pc-entity) used as the viewport, which clips the content to the scroll view's bounds |
 
 </div>
 

--- a/docs/user-manual/web-components/tags/pc-scroll-view.md
+++ b/docs/user-manual/web-components/tags/pc-scroll-view.md
@@ -20,19 +20,19 @@ The `<pc-scroll-view>` tag is used to define a scroll view component, which lets
 | Attribute | Type | Default | Description |
 | --- | --- | --- | --- |
 | `bounce-amount` | Number | `"0.1"` | How far content bounces past its bounds when `scroll-mode="bounce"` (0 to 1) |
-| `content` | String | - | Reference to the content [`<pc-entity>`](../pc-entity) that is moved as the view is scrolled |
+| `content` | Entity Reference | - | Reference to the content [`<pc-entity>`](../pc-entity) that is moved as the view is scrolled |
 | `enabled` | Boolean | `"true"` | Enabled state of the component |
 | `friction` | Number | `"0.05"` | How freely the content moves once thrown (0 = none, 1 = high) |
 | `horizontal` | Boolean | `"true"` | Whether scrolling along the horizontal axis is enabled |
-| `horizontal-scrollbar` | String | - | Reference to the [`<pc-entity>`](../pc-entity) holding the horizontal [`<pc-scrollbar>`](../pc-scrollbar) |
+| `horizontal-scrollbar` | Entity Reference | - | Reference to the [`<pc-entity>`](../pc-entity) holding the horizontal [`<pc-scrollbar>`](../pc-scrollbar) |
 | `horizontal-scrollbar-visibility` | Enum | `"when-required"` | When the horizontal scrollbar is shown: `"always"` \| `"when-required"` |
 | `mouse-wheel-sensitivity` | Vector2 | `"1 1"` | Mouse wheel sensitivity as `x y` (0 on an axis disables wheel scrolling for it) |
 | `scroll-mode` | Enum | `"bounce"` | Behavior when scrolled past bounds: `"clamp"` \| `"bounce"` \| `"infinite"` |
 | `use-mouse-wheel` | Boolean | `"true"` | Whether the scroll view responds to the mouse wheel |
 | `vertical` | Boolean | `"true"` | Whether scrolling along the vertical axis is enabled |
-| `vertical-scrollbar` | String | - | Reference to the [`<pc-entity>`](../pc-entity) holding the vertical [`<pc-scrollbar>`](../pc-scrollbar) |
+| `vertical-scrollbar` | Entity Reference | - | Reference to the [`<pc-entity>`](../pc-entity) holding the vertical [`<pc-scrollbar>`](../pc-scrollbar) |
 | `vertical-scrollbar-visibility` | Enum | `"when-required"` | When the vertical scrollbar is shown: `"always"` \| `"when-required"` |
-| `viewport` | String | - | Reference to the [`<pc-entity>`](../pc-entity) used as the viewport, which clips the content to the scroll view's bounds |
+| `viewport` | Entity Reference | - | Reference to the [`<pc-entity>`](../pc-entity) used as the viewport, which clips the content to the scroll view's bounds |
 
 </div>
 

--- a/docs/user-manual/web-components/tags/pc-scrollbar.md
+++ b/docs/user-manual/web-components/tags/pc-scrollbar.md
@@ -20,7 +20,7 @@ The `<pc-scrollbar>` tag is used to define a scrollbar component, which provides
 | Attribute | Type | Default | Description |
 | --- | --- | --- | --- |
 | `enabled` | Boolean | `"true"` | Enabled state of the component |
-| `handle` | Entity Reference | - | [Reference](../attributes.md#entity-references) (entity `name`, or document-wide `#` selector) to the [`<pc-entity>`](../pc-entity) used as the draggable handle |
+| `handle` | [Entity Reference](../attributes.md#entity-references) | - | The [`<pc-entity>`](../pc-entity) used as the draggable handle |
 | `handle-size` | Number | `"0.5"` | Size of the handle relative to the size of the track (0 to 1) |
 | `orientation` | Enum | `"horizontal"` | Orientation of the scrollbar: `"horizontal"` \| `"vertical"` |
 | `value` | Number | `"0"` | Current position of the scrollbar (0 to 1) |

--- a/docs/user-manual/web-components/tags/pc-scrollbar.md
+++ b/docs/user-manual/web-components/tags/pc-scrollbar.md
@@ -20,7 +20,7 @@ The `<pc-scrollbar>` tag is used to define a scrollbar component, which provides
 | Attribute | Type | Default | Description |
 | --- | --- | --- | --- |
 | `enabled` | Boolean | `"true"` | Enabled state of the component |
-| `handle` | String | - | [Reference](../attributes.md#entity-references) (entity `name`, or document-wide `#` selector) to the [`<pc-entity>`](../pc-entity) used as the draggable handle |
+| `handle` | Entity Reference | - | [Reference](../attributes.md#entity-references) (entity `name`, or document-wide `#` selector) to the [`<pc-entity>`](../pc-entity) used as the draggable handle |
 | `handle-size` | Number | `"0.5"` | Size of the handle relative to the size of the track (0 to 1) |
 | `orientation` | Enum | `"horizontal"` | Orientation of the scrollbar: `"horizontal"` \| `"vertical"` |
 | `value` | Number | `"0"` | Current position of the scrollbar (0 to 1) |

--- a/docs/user-manual/web-components/tags/pc-sky.md
+++ b/docs/user-manual/web-components/tags/pc-sky.md
@@ -17,7 +17,7 @@ The `<pc-sky>` tag is used to define a sky component.
 
 | Attribute | Type | Default | Description |
 | --- | --- | --- | --- |
-| `asset` | String | - | Texture asset ID (must reference a `texture` type asset) |
+| `asset` | Asset ID | - | Texture asset ID (must reference a `texture` type asset) |
 | `center` | Vector3 | `"0 0.01 0"` | Sky center as "X Y Z" values (0-1 range) |
 | `intensity` | Number | `"1"` | Sky brightness intensity |
 | `lighting` | Boolean | `"false"` | Whether the skybox is used as a light source |

--- a/docs/user-manual/web-components/tags/pc-sky.md
+++ b/docs/user-manual/web-components/tags/pc-sky.md
@@ -17,7 +17,7 @@ The `<pc-sky>` tag is used to define a sky component.
 
 | Attribute | Type | Default | Description |
 | --- | --- | --- | --- |
-| `asset` | Asset ID | - | Texture asset ID (must reference a `texture` type asset) |
+| `asset` | [Asset ID](../attributes.md#asset-and-material-ids) | - | Texture asset ID (must reference a `texture` type asset) |
 | `center` | Vector3 | `"0 0.01 0"` | Sky center as "X Y Z" values (0-1 range) |
 | `intensity` | Number | `"1"` | Sky brightness intensity |
 | `lighting` | Boolean | `"false"` | Whether the skybox is used as a light source |

--- a/docs/user-manual/web-components/tags/pc-sound-slot.md
+++ b/docs/user-manual/web-components/tags/pc-sound-slot.md
@@ -17,7 +17,7 @@ The `<pc-sound-slot>` tag is used to define a sound.
 
 | Attribute | Type | Default | Description |
 | --- | --- | --- | --- |
-| `asset` | Asset ID | - | Audio asset ID (must reference an `audio` type asset) |
+| `asset` | [Asset ID](../attributes.md#asset-and-material-ids) | - | Audio asset ID (must reference an `audio` type asset) |
 | `auto-play` | Boolean | `"false"` | Whether the sound plays automatically |
 | `duration` | Number | - | Duration of the sound in seconds (omit to play the full clip) |
 | `loop` | Boolean | `"false"` | Whether the sound loops |

--- a/docs/user-manual/web-components/tags/pc-sound-slot.md
+++ b/docs/user-manual/web-components/tags/pc-sound-slot.md
@@ -17,7 +17,7 @@ The `<pc-sound-slot>` tag is used to define a sound.
 
 | Attribute | Type | Default | Description |
 | --- | --- | --- | --- |
-| `asset` | String | - | Audio asset ID (must reference an `audio` type asset) |
+| `asset` | Asset ID | - | Audio asset ID (must reference an `audio` type asset) |
 | `auto-play` | Boolean | `"false"` | Whether the sound plays automatically |
 | `duration` | Number | - | Duration of the sound in seconds (omit to play the full clip) |
 | `loop` | Boolean | `"false"` | Whether the sound loops |

--- a/i18n/ja/docusaurus-plugin-content-docs/current.json
+++ b/i18n/ja/docusaurus-plugin-content-docs/current.json
@@ -99,9 +99,9 @@
     "message": "PlayCanvas Web Components",
     "description": "The label for category PlayCanvas Web Components in sidebar userManualSidebar"
   },
-  "sidebar.userManualSidebar.category.Tags": {
+  "sidebar.userManualSidebar.category.Tag Reference": {
     "message": "タグリファレンス",
-    "description": "The label for category Tags in sidebar userManualSidebar"
+    "description": "The label for category Tag Reference in sidebar userManualSidebar"
   },
   "sidebar.userManualSidebar.category.PlayCanvas React": {
     "message": "PlayCanvas React",

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/attributes.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/attributes.md
@@ -1,6 +1,6 @@
 ---
 title: 属性
-description: "PlayCanvas Web Componentsの属性が値を解析する方法: デフォルト値の共通契約、Boolean、数値、列挙型、ベクトル、カラー、エンティティ参照。"
+description: "PlayCanvas Web Componentsの属性が値を解析する方法: デフォルト値の共通契約、タイプ列、Boolean、数値、列挙型、ベクトル、カラー、アセットIDとマテリアルID、エンティティ参照。"
 ---
 
 すべてのPlayCanvas Web ComponentはHTML属性を通じて設定します。すべての属性は同じ規約に従うため、一度覚えてしまえば、どのタグがどう動作するかを予測できます。
@@ -20,6 +20,21 @@ description: "PlayCanvas Web Componentsの属性が値を解析する方法: デ
 無効な値がエンジンに到達することはありません。代わりに、属性名と期待されるフォーマットを示すコンソール警告が表示されます。オーサリング中はコンソールを開いておけば、タイプミスがすぐに見つかります。
 
 [`<pc-node>`](tags/pc-node.md)は、上の表の中央の行に対する唯一の例外です。その属性は読み込まれたモデル内のノードに対するオーバーライドであるため、属性が存在しない場合は、エンジンのデフォルト値ではなく、そのモデルがオーサリングされた値が復元されます。
+
+## タイプ列 {#the-type-column}
+
+各属性テーブルの*タイプ*列は、値の書き方を示します。すべてのタイプはこのページで定義しています。
+
+| タイプ | 書き方 |
+| --- | --- |
+| Boolean | `"true"`、`"false"`、または属性名のみ — [Boolean](#booleans)を参照 |
+| Number | 任意の有限な数値 — [数値](#numbers)を参照 |
+| Enum | 決められた名前の集合のうちの1つ。属性の説明に一覧があります — [列挙型](#enums)を参照 |
+| Vector2、Vector3、Vector4 | スペース区切りの2つ、3つ、または4つの数値 — [ベクトル](#vectors)を参照 |
+| Color | CSSカラー名、16進コード、または3つか4つの数値 — [カラー](#colors)を参照 |
+| String | 自由なテキスト。名前、パス、JSONオブジェクトなど |
+| Asset ID、Material ID | [`<pc-asset>`](tags/pc-asset.md)または[`<pc-material>`](tags/pc-material.md)の`id` — [アセットIDとマテリアルID](#asset-and-material-ids)を参照 |
+| Entity Reference | エンティティの`name`、または`#`セレクター — [エンティティ参照](#entity-references)を参照 |
 
 ## Boolean {#booleans}
 
@@ -84,6 +99,19 @@ Invalid value 'bogus' for attribute 'scroll-mode'. Valid values: clamp, bounce, 
 <pc-camera clear-color="#f0f8ff"></pc-camera>
 <pc-light color="1 0.8 0.6"></pc-light>
 ```
+
+## アセットIDとマテリアルID {#asset-and-material-ids}
+
+リソースは[`<pc-app>`](tags/pc-app.md)の直接の子として一度だけ宣言し、付けた`id`で参照します。Asset ID属性は[`<pc-asset>`](tags/pc-asset.md)を、Material ID属性は[`<pc-material>`](tags/pc-material.md)を指定します。
+
+```html
+<pc-asset id="tiles" src="tiles.png"></pc-asset>
+<pc-material id="floor" diffuse-map="tiles"></pc-material>
+<!-- ... -->
+<pc-render type="plane" material="floor"></pc-render>
+```
+
+値は要素自身の`id`を、`#`を付けずにそのまま書きます。CSSセレクターではなく、アプリケーションのレジストリに対する検索だからです。受け付けるアセットタイプは各属性の説明に記載しています。宣言されたリソースのどれにも一致しない`id`は何の効果も持たず、要素はそれまでの状態を保ちます。[`<pc-model>`](tags/pc-model.md)はさらに、見つからなかったアセットの名前を含む警告をログに出力します。
 
 ## エンティティ参照 {#entity-references}
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/index.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/index.md
@@ -1,19 +1,137 @@
 ---
 title: タグリファレンス
-description: "PlayCanvas Web Componentのタグをアルファベット順に一覧し、各要素の属性と使い方の詳細ドキュメントへ短い要約でリンクします。"
+description: "PlayCanvas Web Componentsのすべてのタグを役割別にまとめ、タグが構成するドキュメント構造と、各要素の属性、イベント、配置ルールのリファレンスへのリンクを示します。"
 ---
 
-以下は、PlayCanvas Web Components で利用可能なタグの完全なリストです。
+PlayCanvas Web Components のすべてのタグを、役割別にまとめて掲載します。タグが構成するドキュメント構造を示し、各タグのリファレンスページにリンクします。
 
-すべてのタグの属性は同じ値の規約を共有します。属性が存在しない（または削除された）場合はエンジンのデフォルト値が適用され、無効な値はコンソール警告をログに出力してデフォルト値にフォールバックします。Boolean、数値、列挙型、ベクトル、カラーの記述方法については[属性](../attributes.md)を参照してください。
+## タグの組み合わせ方 {#how-the-tags-fit-together}
 
-タグには配置ルールもあります。各タグのページに必要な親要素が記載されています。誤った場所に配置された要素は、受け付ける親要素の名前を含むコンソール警告をログに出力するため、オーサリング中はコンソールを開いておいてください。
+どのドキュメントも同じ形をしています。[`<pc-app>`](pc-app) がリソースと1つの [`<pc-scene>`](pc-scene) を保持し、シーンがエンティティを保持し、エンティティが必要な各コンポーネントタグを1つずつと、子エンティティを保持します。
 
-エンジンのエンティティを表すタグは3つあり、コンポーネントタグはそのいずれの内側にも置けます。[`<pc-entity>`](pc-entity)、[`<pc-model>`](pc-model)、[`<pc-node>`](pc-node)です。つまり、モデルの内側に置いたコンポーネントはそのモデルに取り付けられ、ノードの内側に置いたコンポーネントはそのノードに取り付けられます。どちらもエンティティと同じコンポーネントの子を取ります。
+```html
+<pc-app>
+    <!-- リソースは一度だけ宣言し、id で参照します -->
+    <pc-asset id="sky" src="sky.webp"></pc-asset>
+    <pc-asset id="robot" src="robot.glb"></pc-asset>
+    <pc-material id="gold" diffuse="#d4af37" metalness="1"></pc-material>
+    <pc-wasm name="Ammo" glue="ammo.js" wasm="ammo.wasm"></pc-wasm>
+    <pc-scene>
+        <pc-sky asset="sky"></pc-sky>
+        <!-- エンティティは各コンポーネントタグを1つずつ取り、エンティティやモデルをネストできます -->
+        <pc-entity name="camera" position="0 2 6">
+            <pc-camera></pc-camera>
+        </pc-entity>
+        <pc-entity name="crate" position="0 3 0">
+            <pc-render type="box" material="gold"></pc-render>
+            <pc-collision></pc-collision>
+            <pc-rigid-body type="dynamic"></pc-rigid-body>
+        </pc-entity>
+        <!-- モデルは GLB をインスタンス化するエンティティで、ノードはその内側のノードにバインドします -->
+        <pc-model asset="robot">
+            <pc-anim clip="idle">
+                <pc-anim-clip name="idle"></pc-anim-clip>
+            </pc-anim>
+            <pc-node name="head">
+                <pc-light type="spot"></pc-light>
+            </pc-node>
+        </pc-model>
+    </pc-scene>
+</pc-app>
+```
+
+エンジンのエンティティを表すタグは3つあり、コンポーネントタグはそのいずれの内側にも置けます。[`<pc-entity>`](pc-entity)、[`<pc-model>`](pc-model)、[`<pc-node>`](pc-node)です。モデルの内側に置いたコンポーネントはそのモデルのホストエンティティに取り付けられ、ノードの内側に置いたコンポーネントはバインドされたノードに取り付けられます。どちらもエンティティと同じコンポーネントの子を取ります。
+
+各タグのページに必要な親要素が記載されています。誤った場所に配置された要素は、受け付ける親要素の名前を含むコンソール警告をログに出力するため、オーサリング中はコンソールを開いておいてください。
+
+## 役割別のタグ {#tags-by-role}
+
+### 構造 {#structure}
+
+ドキュメントを形作る5つのタグです。アプリケーション、そのシーン、そしてエンティティを表す3つのタグです。
+
+| タグ | 説明 |
+| --- | --- |
+| [`<pc-app>`](pc-app) | アプリケーションのルート要素を定義します。グラフィックスデバイスと、保持するリソースおよびシーンです。 |
+| [`<pc-scene>`](pc-scene) | シーンを定義します。内側のすべてに適用されるフォグ、露出、重力を持ちます。 |
+| [`<pc-entity>`](pc-entity) | エンティティを定義します。コンポーネントタグと子エンティティをホストする、名前付きのトランスフォームです。 |
+| [`<pc-model>`](pc-model) | GLBファイルから3Dモデルをインスタンス化するエンティティを定義します。 |
+| [`<pc-node>`](pc-node) | 読み込まれたモデル内のノードにバインドしてオーバーライドします。 |
+
+### リソース {#resources}
+
+`<pc-app>` の直接の子です。一度だけ宣言し、利用するタグから `id` で参照します。
+
+| タグ | 説明 |
+| --- | --- |
+| [`<pc-asset>`](pc-asset) | アプリケーションによってロードされるアセットを定義します。 |
+| [`<pc-material>`](pc-material) | レンダーコンポーネントが参照できるマテリアルを定義します。 |
+| [`<pc-wasm>`](pc-wasm) | Ammo物理エンジンなどのWebAssemblyモジュールを定義します。 |
+
+### レンダリング {#rendering}
+
+| タグ | 説明 |
+| --- | --- |
+| [`<pc-camera>`](pc-camera) | シーンのレンダリングに使用されるカメラを定義します。 |
+| [`<pc-light>`](pc-light) | ディレクショナル、オムニ、スポットのライトを定義します。影も設定できます。 |
+| [`<pc-render>`](pc-render) | マテリアルを付けてプリミティブ形状を描くレンダーコンポーネントを定義します。 |
+| [`<pc-gsplat>`](pc-gsplat) | 3D Gaussian Splats をレンダリングする gsplat コンポーネントを定義します。 |
+| [`<pc-particle-system>`](pc-particle-system) | JSON設定アセットで駆動するパーティクルシステムを定義します。 |
+| [`<pc-sky>`](pc-sky) | 画像ベースのスカイボックスを定義します。 |
+
+### アニメーション {#animation}
+
+| タグ | 説明 |
+| --- | --- |
+| [`<pc-anim>`](pc-anim) | アニメーションクリップを再生するアニメーションコンポーネントを定義します。 |
+| [`<pc-anim-clip>`](pc-anim-clip) | アニメーションコンポーネントに割り当てる1つのクリップを定義します。 |
+
+### 物理 {#physics}
+
+物理には Ammo モジュールが必要です。[`<pc-wasm>`](pc-wasm) で宣言します。
+
+| タグ | 説明 |
+| --- | --- |
+| [`<pc-collision>`](pc-collision) | トリガーとリジッドボディによって使用される衝突コンポーネントを定義します。 |
+| [`<pc-rigid-body>`](pc-rigid-body) | 静的、動的、キネマティックのリジッドボディを定義します。 |
+| [`<pc-joint>`](pc-joint) | 2つのリジッドボディを拘束する物理ジョイントを定義します。 |
+
+### ユーザーインターフェース {#user-interface}
+
+[`<pc-screen>`](pc-screen) は、それぞれが [`<pc-element>`](pc-element) を持つエンティティのツリーをホストします。その他のタグは、それらの要素の振る舞いを細かく指定します。
+
+| タグ | 説明 |
+| --- | --- |
+| [`<pc-screen>`](pc-screen) | 要素コンポーネントをレンダリングできるスクリーンコンポーネントを定義します。 |
+| [`<pc-element>`](pc-element) | テキスト、画像、またはグループユーザーインターフェース要素を定義します。 |
+| [`<pc-button>`](pc-button) | ホバー、押下、非アクティブの状態を持つボタンコンポーネントを定義します。 |
+| [`<pc-layout-group>`](pc-layout-group) | 子要素を行または列に配置するレイアウトグループを定義します。 |
+| [`<pc-layout-child>`](pc-layout-child) | レイアウトグループ内での子ごとのサイズ規則を定義します。 |
+| [`<pc-scroll-view>`](pc-scroll-view) | コンテンツエンティティの上に載るスクロール可能なビューポートを定義します。 |
+| [`<pc-scrollbar>`](pc-scrollbar) | スクロールビューを操作するドラッグ可能なスクロールバーを定義します。 |
+
+### オーディオ {#audio}
+
+| タグ | 説明 |
+| --- | --- |
+| [`<pc-sound>`](pc-sound) | サウンドスロットを保持するサウンドコンポーネントを定義します。 |
+| [`<pc-sound-slot>`](pc-sound-slot) | サウンドコンポーネントに割り当てられる単一のサウンドを定義します。 |
+| [`<pc-audio-listener>`](pc-audio-listener) | 位置音源を聴く地点を定義します。 |
+
+### スクリプティング {#scripting}
+
+| タグ | 説明 |
+| --- | --- |
+| [`<pc-script>`](pc-script) | スクリプトインスタンスをホストするスクリプトコンポーネントを定義します。 |
+| [`<pc-script-instance>`](pc-script-instance) | スクリプトコンポーネントに割り当てられる単一のスクリプトを定義します。 |
+
+## 共通の規約 {#shared-conventions}
+
+すべてのタグの属性は同じ値の規約を共有します。属性が存在しない（または削除された）場合はエンジンのデフォルト値が適用され、無効な値はコンソール警告をログに出力してデフォルト値にフォールバックします。各属性テーブルの*タイプ*列は値の書き方を示します。Boolean、Number、Enum、Vector、Color、String、またはアセット・マテリアル・エンティティへの参照です。これらのタイプはすべて[属性](../attributes.md)で定義しています。
 
 :::note[コンポーネントタグは、それが追加するエンジンのコンポーネントを名前で表します]
 
-`pc-`プレフィックスを外し、ハイフンを取り除くと、エンジンのコンポーネントIDになります。`<pc-layout-group>`は`entity.layoutgroup`を、`<pc-rigid-body>`は`entity.rigidbody`を、`<pc-audio-listener>`は`entity.audiolistener`を追加します。このルールは以下のすべてのコンポーネントタグで双方向に成り立つため、どちらの綴りも暗記する必要はありません。エンジンのIDが単語を続けて書くのは、それがハイフンを含められないJavaScriptのプロパティ名だからにすぎません。HTMLのタグにはその制約がありません。
+`pc-`プレフィックスを外し、ハイフンを取り除くと、エンジンのコンポーネントIDになります。`<pc-layout-group>`は`entity.layoutgroup`を、`<pc-rigid-body>`は`entity.rigidbody`を、`<pc-audio-listener>`は`entity.audiolistener`を追加します。このルールはこのページのすべてのコンポーネントタグで双方向に成り立つため、どちらの綴りも暗記する必要はありません。エンジンのIDが単語を続けて書くのは、それがハイフンを含められないJavaScriptのプロパティ名だからにすぎません。HTMLのタグにはその制約がありません。
 
 :::
 
@@ -21,36 +139,6 @@ description: "PlayCanvas Web Componentのタグをアルファベット順に一
 
 [`<pc-material>`](pc-material)を除くすべてのタグは非同期に初期化され、初期化が完了すると`ready`イベントを発火します。そのタイミングと、これをラップする`whenReady()`ヘルパーについては[`ready`イベント](../programmatic-access.md#the-ready-event)を参照してください。各タグのページのイベントセクションには、そのタグに固有のイベントのみを記載しています。
 
-| タグ | 説明 |
-| --- | --- |
-| [`<pc-anim>`](pc-anim) | アニメーションクリップを再生するアニメーションコンポーネントを定義します。 |
-| [`<pc-anim-clip>`](pc-anim-clip) | アニメーションコンポーネントに割り当てる1つのクリップを定義します。 |
-| [`<pc-app>`](pc-app) | アプリケーションのルート要素を定義します。 |
-| [`<pc-asset>`](pc-asset) | アプリケーションによってロードされるアセットを定義します。 |
-| [`<pc-audio-listener>`](pc-audio-listener) | オーディオリスナーコンポーネントを定義します。 |
-| [`<pc-button>`](pc-button) | ボタンコンポーネントを定義します。 |
-| [`<pc-camera>`](pc-camera) | シーンのレンダリングに使用されるカメラを定義します。 |
-| [`<pc-collision>`](pc-collision) | トリガーとリジッドボディによって使用される衝突コンポーネントを定義します。 |
-| [`<pc-element>`](pc-element) | テキスト、画像、またはグループユーザーインターフェース要素を定義します。 |
-| [`<pc-entity>`](pc-entity) | エンティティを定義します。 |
-| [`<pc-gsplat>`](pc-gsplat) | 3D Gaussian Splats をレンダリングする gsplat コンポーネントを定義します。 |
-| [`<pc-joint>`](pc-joint) | 2つのリジッドボディを拘束する物理ジョイントを定義します。 |
-| [`<pc-layout-child>`](pc-layout-child) | レイアウトの子コンポーネントを定義します。 |
-| [`<pc-layout-group>`](pc-layout-group) | レイアウトグループコンポーネントを定義します。 |
-| [`<pc-light>`](pc-light) | ライトコンポーネントを定義します。 |
-| [`<pc-material>`](pc-material) | レンダーコンポーネントが参照できるマテリアルを定義します。 |
-| [`<pc-model>`](pc-model) | GLBファイルから3Dモデルをインスタンス化するエンティティを定義します。 |
-| [`<pc-node>`](pc-node) | 読み込まれたモデル内のノードにバインドしてオーバーライドします。 |
-| [`<pc-particle-system>`](pc-particle-system) | パーティクルシステムコンポーネントを定義します。 |
-| [`<pc-render>`](pc-render) | レンダーコンポーネントを定義します。 |
-| [`<pc-rigid-body>`](pc-rigid-body) | リジッドボディコンポーネントを定義します。 |
-| [`<pc-scene>`](pc-scene) | シーンを定義します。 |
-| [`<pc-screen>`](pc-screen) | 要素コンポーネントをレンダリングできるスクリーンコンポーネントを定義します。 |
-| [`<pc-script>`](pc-script) | スクリプトコンポーネントを定義します。 |
-| [`<pc-script-instance>`](pc-script-instance) | スクリプトコンポーネントに割り当てられる単一のスクリプトを定義します。 |
-| [`<pc-scrollbar>`](pc-scrollbar) | スクロールバーコンポーネントを定義します。 |
-| [`<pc-scroll-view>`](pc-scroll-view) | スクロールビューコンポーネントを定義します。 |
-| [`<pc-sky>`](pc-sky) | 画像ベースのスカイボックスを定義します。 |
-| [`<pc-sound>`](pc-sound) | サウンドコンポーネントを定義します。 |
-| [`<pc-sound-slot>`](pc-sound-slot) | サウンドコンポーネントに割り当てられる単一のサウンドを定義します。 |
-| [`<pc-wasm>`](pc-wasm) | WebAssemblyモジュールを定義します。 |
+## すべてのタグ（A–Z） {#all-tags-a-z}
+
+[`<pc-anim>`](pc-anim)・[`<pc-anim-clip>`](pc-anim-clip)・[`<pc-app>`](pc-app)・[`<pc-asset>`](pc-asset)・[`<pc-audio-listener>`](pc-audio-listener)・[`<pc-button>`](pc-button)・[`<pc-camera>`](pc-camera)・[`<pc-collision>`](pc-collision)・[`<pc-element>`](pc-element)・[`<pc-entity>`](pc-entity)・[`<pc-gsplat>`](pc-gsplat)・[`<pc-joint>`](pc-joint)・[`<pc-layout-child>`](pc-layout-child)・[`<pc-layout-group>`](pc-layout-group)・[`<pc-light>`](pc-light)・[`<pc-material>`](pc-material)・[`<pc-model>`](pc-model)・[`<pc-node>`](pc-node)・[`<pc-particle-system>`](pc-particle-system)・[`<pc-render>`](pc-render)・[`<pc-rigid-body>`](pc-rigid-body)・[`<pc-scene>`](pc-scene)・[`<pc-screen>`](pc-screen)・[`<pc-script>`](pc-script)・[`<pc-script-instance>`](pc-script-instance)・[`<pc-scrollbar>`](pc-scrollbar)・[`<pc-scroll-view>`](pc-scroll-view)・[`<pc-sky>`](pc-sky)・[`<pc-sound>`](pc-sound)・[`<pc-sound-slot>`](pc-sound-slot)・[`<pc-wasm>`](pc-wasm)

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-anim-clip.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-anim-clip.md
@@ -56,7 +56,7 @@ description: "pc-anim-clip要素のリファレンス: pc-animコンポーネン
 
 | 属性 | 型 | デフォルト | 説明 |
 | --- | --- | --- | --- |
-| `asset` | Asset ID | - | トラックを供給する[`<pc-asset>`](../pc-asset)のID。`container`、`animation`のGLB、`animclip`のJSONのいずれかです。空の場合は囲んでいる[`<pc-model>`](../pc-model)から取得します |
+| `asset` | [Asset ID](../attributes.md#asset-and-material-ids) | - | トラックを供給する[`<pc-asset>`](../pc-asset)のID。`container`、`animation`のGLB、`animclip`のJSONのいずれかです。空の場合は囲んでいる[`<pc-model>`](../pc-model)から取得します |
 | `loop` | Boolean | `"true"` | クリップをループさせるかどうか。ループしないクリップは終了時に最後のポーズを保持します |
 | `name` | String | - | クリップの名前であり、供給元から探すトラックの名前。コンポーネント内で一意で、`.`を含められません |
 | `speed` | Number | `"1"` | このクリップの再生速度。負の値で逆再生します |

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-anim-clip.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-anim-clip.md
@@ -56,7 +56,7 @@ description: "pc-anim-clip要素のリファレンス: pc-animコンポーネン
 
 | 属性 | 型 | デフォルト | 説明 |
 | --- | --- | --- | --- |
-| `asset` | String | - | トラックを供給する[`<pc-asset>`](../pc-asset)のID。`container`、`animation`のGLB、`animclip`のJSONのいずれかです。空の場合は囲んでいる[`<pc-model>`](../pc-model)から取得します |
+| `asset` | Asset ID | - | トラックを供給する[`<pc-asset>`](../pc-asset)のID。`container`、`animation`のGLB、`animclip`のJSONのいずれかです。空の場合は囲んでいる[`<pc-model>`](../pc-model)から取得します |
 | `loop` | Boolean | `"true"` | クリップをループさせるかどうか。ループしないクリップは終了時に最後のポーズを保持します |
 | `name` | String | - | クリップの名前であり、供給元から探すトラックの名前。コンポーネント内で一意で、`.`を含められません |
 | `speed` | Number | `"1"` | このクリップの再生速度。負の値で逆再生します |

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-asset.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-asset.md
@@ -20,7 +20,7 @@ description: "pc-asset要素のリファレンス: URLで読み込むアセッ�
 | `address-u` | Enum | `"repeat"` | `texture` および `textureatlas` アセットの場合: 0から1の範囲外の座標を水平方向にどうサンプリングするか — `"repeat"` \| `"clamp"` \| `"mirror"` |
 | `address-v` | Enum | `"repeat"` | `texture` および `textureatlas` アセットの場合: 0から1の範囲外の座標を垂直方向にどうサンプリングするか — `"repeat"` \| `"clamp"` \| `"mirror"` |
 | `anisotropy` | Number | `"1"` | `texture` および `textureatlas` アセットの場合: 異方性フィルタリングの最大レベル。浅い視野角での品質が向上します |
-| `atlas` | String | - | `sprite` アセットの場合: このスプライトが読み込む `textureatlas` `<pc-asset>` の `id`。アトラスはスプライトより前に宣言する必要があります |
+| `atlas` | Asset ID | - | `sprite` アセットの場合: このスプライトが読み込む `textureatlas` `<pc-asset>` の `id`。アトラスはスプライトより前に宣言する必要があります |
 | `data` | String | - | インラインのJSONアセットデータ。テクスチャアトラス（フレーム定義）やスプライトで使用されます |
 | `flip-y` | Boolean | `"false"` | `texture` および `textureatlas` アセットの場合: アップロード時に画像データを垂直方向に反転するかどうか |
 | `frame-keys` | String | - | `sprite` アセットの場合: スプライトを構成するアトラスのフレームキーを、スペースまたはカンマ区切りで指定したリスト |

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-asset.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-asset.md
@@ -20,7 +20,7 @@ description: "pc-asset要素のリファレンス: URLで読み込むアセッ�
 | `address-u` | Enum | `"repeat"` | `texture` および `textureatlas` アセットの場合: 0から1の範囲外の座標を水平方向にどうサンプリングするか — `"repeat"` \| `"clamp"` \| `"mirror"` |
 | `address-v` | Enum | `"repeat"` | `texture` および `textureatlas` アセットの場合: 0から1の範囲外の座標を垂直方向にどうサンプリングするか — `"repeat"` \| `"clamp"` \| `"mirror"` |
 | `anisotropy` | Number | `"1"` | `texture` および `textureatlas` アセットの場合: 異方性フィルタリングの最大レベル。浅い視野角での品質が向上します |
-| `atlas` | Asset ID | - | `sprite` アセットの場合: このスプライトが読み込む `textureatlas` `<pc-asset>` の `id`。アトラスはスプライトより前に宣言する必要があります |
+| `atlas` | [Asset ID](../attributes.md#asset-and-material-ids) | - | `sprite` アセットの場合: このスプライトが読み込む `textureatlas` `<pc-asset>` の `id`。アトラスはスプライトより前に宣言する必要があります |
 | `data` | String | - | インラインのJSONアセットデータ。テクスチャアトラス（フレーム定義）やスプライトで使用されます |
 | `flip-y` | Boolean | `"false"` | `texture` および `textureatlas` アセットの場合: アップロード時に画像データを垂直方向に反転するかどうか |
 | `frame-keys` | String | - | `sprite` アセットの場合: スプライトを構成するアトラスのフレームキーを、スペースまたはカンマ区切りで指定したリスト |

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-button.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-button.md
@@ -22,14 +22,14 @@ description: "pc-button要素のリファレンス: ホバー、押下、非ア�
 | `enabled` | Boolean | `"true"` | コンポーネントの有効状態 |
 | `fade-duration` | Number | `"0"` | ティント遷移を適用する時間（ミリ秒） |
 | `hit-padding` | Vector4 | `"0 0 0 0"` | ボタンのヒット領域を `left bottom right top` で拡張します |
-| `hover-sprite-asset` | String | - | ホバー時に表示されるスプライト [`<pc-asset>`](../pc-asset) のid（スプライト遷移モード） |
+| `hover-sprite-asset` | Asset ID | - | ホバー時に表示されるスプライト [`<pc-asset>`](../pc-asset) のid（スプライト遷移モード） |
 | `hover-sprite-frame` | Number | `"0"` | ホバースプライトのフレーム |
 | `hover-tint` | Color | `"1 1 1 1"` | ホバー時にイメージエンティティに適用されるティント（ティント遷移モード） |
-| `image` | String | - | 視覚的な遷移を表示するイメージ要素を持つ [`<pc-entity>`](../pc-entity) への[参照](../attributes.md#entity-references)（エンティティの `name`、またはドキュメント全体の `#` セレクター）。デフォルトはボタン自身のエンティティです。[`<pc-model>`](../pc-model)の内側ではそれがモデルのホストになるため、その場合はUIエンティティを明示的に指定してください |
-| `inactive-sprite-asset` | String | - | 非アクティブ時に表示されるスプライト [`<pc-asset>`](../pc-asset) のid（スプライト遷移モード） |
+| `image` | Entity Reference | - | 視覚的な遷移を表示するイメージ要素を持つ [`<pc-entity>`](../pc-entity) への[参照](../attributes.md#entity-references)（エンティティの `name`、またはドキュメント全体の `#` セレクター）。デフォルトはボタン自身のエンティティです。[`<pc-model>`](../pc-model)の内側ではそれがモデルのホストになるため、その場合はUIエンティティを明示的に指定してください |
+| `inactive-sprite-asset` | Asset ID | - | 非アクティブ時に表示されるスプライト [`<pc-asset>`](../pc-asset) のid（スプライト遷移モード） |
 | `inactive-sprite-frame` | Number | `"0"` | 非アクティブスプライトのフレーム |
 | `inactive-tint` | Color | `"1 1 1 1"` | 非アクティブ時にイメージエンティティに適用されるティント（ティント遷移モード） |
-| `pressed-sprite-asset` | String | - | 押下時に表示されるスプライト [`<pc-asset>`](../pc-asset) のid（スプライト遷移モード） |
+| `pressed-sprite-asset` | Asset ID | - | 押下時に表示されるスプライト [`<pc-asset>`](../pc-asset) のid（スプライト遷移モード） |
 | `pressed-sprite-frame` | Number | `"0"` | 押下スプライトのフレーム |
 | `pressed-tint` | Color | `"1 1 1 1"` | 押下時にイメージエンティティに適用されるティント（ティント遷移モード） |
 | `transition-mode` | Enum | `"tint"` | ボタンがホバー/押下に反応する方法: `"tint"` \| `"sprite"` |

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-button.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-button.md
@@ -22,14 +22,14 @@ description: "pc-button要素のリファレンス: ホバー、押下、非ア�
 | `enabled` | Boolean | `"true"` | コンポーネントの有効状態 |
 | `fade-duration` | Number | `"0"` | ティント遷移を適用する時間（ミリ秒） |
 | `hit-padding` | Vector4 | `"0 0 0 0"` | ボタンのヒット領域を `left bottom right top` で拡張します |
-| `hover-sprite-asset` | Asset ID | - | ホバー時に表示されるスプライト [`<pc-asset>`](../pc-asset) のid（スプライト遷移モード） |
+| `hover-sprite-asset` | [Asset ID](../attributes.md#asset-and-material-ids) | - | ホバー時に表示されるスプライト [`<pc-asset>`](../pc-asset) のid（スプライト遷移モード） |
 | `hover-sprite-frame` | Number | `"0"` | ホバースプライトのフレーム |
 | `hover-tint` | Color | `"1 1 1 1"` | ホバー時にイメージエンティティに適用されるティント（ティント遷移モード） |
-| `image` | Entity Reference | - | 視覚的な遷移を表示するイメージ要素を持つ [`<pc-entity>`](../pc-entity) への[参照](../attributes.md#entity-references)（エンティティの `name`、またはドキュメント全体の `#` セレクター）。デフォルトはボタン自身のエンティティです。[`<pc-model>`](../pc-model)の内側ではそれがモデルのホストになるため、その場合はUIエンティティを明示的に指定してください |
-| `inactive-sprite-asset` | Asset ID | - | 非アクティブ時に表示されるスプライト [`<pc-asset>`](../pc-asset) のid（スプライト遷移モード） |
+| `image` | [Entity Reference](../attributes.md#entity-references) | - | 視覚的な遷移を表示するイメージ要素を持つ [`<pc-entity>`](../pc-entity)。デフォルトはボタン自身のエンティティです。[`<pc-model>`](../pc-model)の内側ではそれがモデルのホストになるため、その場合はUIエンティティを明示的に指定してください |
+| `inactive-sprite-asset` | [Asset ID](../attributes.md#asset-and-material-ids) | - | 非アクティブ時に表示されるスプライト [`<pc-asset>`](../pc-asset) のid（スプライト遷移モード） |
 | `inactive-sprite-frame` | Number | `"0"` | 非アクティブスプライトのフレーム |
 | `inactive-tint` | Color | `"1 1 1 1"` | 非アクティブ時にイメージエンティティに適用されるティント（ティント遷移モード） |
-| `pressed-sprite-asset` | Asset ID | - | 押下時に表示されるスプライト [`<pc-asset>`](../pc-asset) のid（スプライト遷移モード） |
+| `pressed-sprite-asset` | [Asset ID](../attributes.md#asset-and-material-ids) | - | 押下時に表示されるスプライト [`<pc-asset>`](../pc-asset) のid（スプライト遷移モード） |
 | `pressed-sprite-frame` | Number | `"0"` | 押下スプライトのフレーム |
 | `pressed-tint` | Color | `"1 1 1 1"` | 押下時にイメージエンティティに適用されるティント（ティント遷移モード） |
 | `transition-mode` | Enum | `"tint"` | ボタンがホバー/押下に反応する方法: `"tint"` \| `"sprite"` |

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-element.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-element.md
@@ -33,7 +33,7 @@ description: "pc-element要素のリファレンス: フォント、スプライ
 | `color` | Color | `"1 1 1 1"` | スペース区切りのRGBA値、16進数コード、または[名前付きカラー](https://github.com/playcanvas/web-components/blob/main/src/colors.ts)としての色 |
 | `enable-markup` | Boolean | `"false"` | スタイル付きテキストのマークアップ処理を有効にします。色付きテキストの場合は `[color="#ff0000"]text[/color]` などのタグをサポートします。 |
 | `enabled` | Boolean | `"true"` | コンポーネントの有効状態 |
-| `font-asset` | Asset ID | - | フォント [`<pc-asset>`](../pc-asset) のID (`font` 型アセットを参照する必要があります)。テキスト要素でのみ必須です |
+| `font-asset` | [Asset ID](../attributes.md#asset-and-material-ids) | - | フォント [`<pc-asset>`](../pc-asset) のID (`font` 型アセットを参照する必要があります)。テキスト要素でのみ必須です |
 | `font-size` | Number | `"32"` | ピクセル単位のフォントサイズ |
 | `height` | Number | `"0"` | ピクセル単位の高さ (自動サイズ調整の場合は0) |
 | `line-height` | Number | `"32"` | ピクセル単位の行の高さ |
@@ -44,10 +44,10 @@ description: "pc-element要素のリファレンス: フォント、スプライ
 | `opacity` | Number | `"1"` | 不透明度。0（透明）〜1（不透明） |
 | `pivot` | Vector2 | `"0.5 0.5"` | "X Y" 値としてのピボットポイント |
 | `pixels-per-unit` | Number | - | スプライトをレンダリングするときに使用される、ユニットあたりのピクセル数。イメージ要素のみ |
-| `sprite-asset` | Asset ID | - | レンダリングするスプライト [`<pc-asset>`](../pc-asset) のID。イメージ要素のみ |
+| `sprite-asset` | [Asset ID](../attributes.md#asset-and-material-ids) | - | レンダリングするスプライト [`<pc-asset>`](../pc-asset) のID。イメージ要素のみ |
 | `sprite-frame` | Number | `"0"` | レンダリングするスプライトのフレームインデックス。イメージ要素のみ |
 | `text` | String | - | 表示するテキストコンテンツ |
-| `texture-asset` | Asset ID | - | レンダリングするテクスチャ [`<pc-asset>`](../pc-asset) のID。イメージ要素のみ |
+| `texture-asset` | [Asset ID](../attributes.md#asset-and-material-ids) | - | レンダリングするテクスチャ [`<pc-asset>`](../pc-asset) のID。イメージ要素のみ |
 | `type` | Enum | `"group"` | 要素の型: `"group"` \| `"image"` \| `"text"` |
 | `use-input` | Boolean | `"false"` | 要素がポインター入力を受け取るかどうか。[`<pc-button>`](../pc-button) とスクロールビューの操作に必要です |
 | `width` | Number | `"0"` | ピクセル単位の幅 (自動サイズ調整の場合は0) |

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-element.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-element.md
@@ -33,7 +33,7 @@ description: "pc-element要素のリファレンス: フォント、スプライ
 | `color` | Color | `"1 1 1 1"` | スペース区切りのRGBA値、16進数コード、または[名前付きカラー](https://github.com/playcanvas/web-components/blob/main/src/colors.ts)としての色 |
 | `enable-markup` | Boolean | `"false"` | スタイル付きテキストのマークアップ処理を有効にします。色付きテキストの場合は `[color="#ff0000"]text[/color]` などのタグをサポートします。 |
 | `enabled` | Boolean | `"true"` | コンポーネントの有効状態 |
-| `font-asset` | String | - | フォント [`<pc-asset>`](../pc-asset) のID (`font` 型アセットを参照する必要があります)。テキスト要素でのみ必須です |
+| `font-asset` | Asset ID | - | フォント [`<pc-asset>`](../pc-asset) のID (`font` 型アセットを参照する必要があります)。テキスト要素でのみ必須です |
 | `font-size` | Number | `"32"` | ピクセル単位のフォントサイズ |
 | `height` | Number | `"0"` | ピクセル単位の高さ (自動サイズ調整の場合は0) |
 | `line-height` | Number | `"32"` | ピクセル単位の行の高さ |
@@ -44,10 +44,10 @@ description: "pc-element要素のリファレンス: フォント、スプライ
 | `opacity` | Number | `"1"` | 不透明度。0（透明）〜1（不透明） |
 | `pivot` | Vector2 | `"0.5 0.5"` | "X Y" 値としてのピボットポイント |
 | `pixels-per-unit` | Number | - | スプライトをレンダリングするときに使用される、ユニットあたりのピクセル数。イメージ要素のみ |
-| `sprite-asset` | String | - | レンダリングするスプライト [`<pc-asset>`](../pc-asset) のID。イメージ要素のみ |
+| `sprite-asset` | Asset ID | - | レンダリングするスプライト [`<pc-asset>`](../pc-asset) のID。イメージ要素のみ |
 | `sprite-frame` | Number | `"0"` | レンダリングするスプライトのフレームインデックス。イメージ要素のみ |
 | `text` | String | - | 表示するテキストコンテンツ |
-| `texture-asset` | String | - | レンダリングするテクスチャ [`<pc-asset>`](../pc-asset) のID。イメージ要素のみ |
+| `texture-asset` | Asset ID | - | レンダリングするテクスチャ [`<pc-asset>`](../pc-asset) のID。イメージ要素のみ |
 | `type` | Enum | `"group"` | 要素の型: `"group"` \| `"image"` \| `"text"` |
 | `use-input` | Boolean | `"false"` | 要素がポインター入力を受け取るかどうか。[`<pc-button>`](../pc-button) とスクロールビューの操作に必要です |
 | `width` | Number | `"0"` | ピクセル単位の幅 (自動サイズ調整の場合は0) |

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-gsplat.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-gsplat.md
@@ -19,7 +19,7 @@ description: "pc-gsplat要素のリファレンス: Gaussian splat Assetをレ�
 
 | 属性 | タイプ | デフォルト | 説明 |
 | --- | --- | --- | --- |
-| `asset` | String | - | Gaussian splatアセットID (`gsplat`タイプのアセットを参照する必要があります) |
+| `asset` | Asset ID | - | Gaussian splatアセットID (`gsplat`タイプのアセットを参照する必要があります) |
 | `cast-shadows` | Boolean | `"false"` | gsplatコンポーネントが影を落とすかどうか |
 | `enabled` | Boolean | `"true"` | コンポーネントの有効状態 |
 | `lod-base-distance` | Number | `"5"` | 最初のLOD遷移 (LOD 0 から LOD 1) の距離。これより近いスプラットは最高品質のLODを使用します。最小値は`0.1`。LODレベルを含むアセットにのみ影響します。 |

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-gsplat.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-gsplat.md
@@ -19,7 +19,7 @@ description: "pc-gsplat要素のリファレンス: Gaussian splat Assetをレ�
 
 | 属性 | タイプ | デフォルト | 説明 |
 | --- | --- | --- | --- |
-| `asset` | Asset ID | - | Gaussian splatアセットID (`gsplat`タイプのアセットを参照する必要があります) |
+| `asset` | [Asset ID](../attributes.md#asset-and-material-ids) | - | Gaussian splatアセットID (`gsplat`タイプのアセットを参照する必要があります) |
 | `cast-shadows` | Boolean | `"false"` | gsplatコンポーネントが影を落とすかどうか |
 | `enabled` | Boolean | `"true"` | コンポーネントの有効状態 |
 | `lod-base-distance` | Number | `"5"` | 最初のLOD遷移 (LOD 0 から LOD 1) の距離。これより近いスプラットは最高品質のLODを使用します。最小値は`0.1`。LODレベルを含むアセットにのみ影響します。 |

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-joint.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-joint.md
@@ -60,8 +60,8 @@ description: "pc-joint要素のリファレンス: fixed・ball・hinge・slider
 | `enable-collision` | Boolean | `"false"` | 拘束される2つのボディが互いに衝突するかどうか |
 | `enable-limits` | Boolean | `"false"` | ジョイントのリミットを適用するかどうか。これを設定するまでリミット系の属性は効果がありません |
 | `enabled` | Boolean | `"true"` | コンポーネントの有効状態 |
-| `entity-a` | Entity Reference | - | 1つ目のボディを提供する[`<pc-entity>`](../pc-entity)への参照。[`<pc-rigid-body>`](../pc-rigid-body)が必要です |
-| `entity-b` | Entity Reference | - | 2つ目のボディを提供する[`<pc-entity>`](../pc-entity)への参照。空にすると`entity-a`をワールド空間の固定点に拘束します |
+| `entity-a` | [Entity Reference](../attributes.md#entity-references) | - | 1つ目のボディを提供する[`<pc-entity>`](../pc-entity)への参照。[`<pc-rigid-body>`](../pc-rigid-body)が必要です |
+| `entity-b` | [Entity Reference](../attributes.md#entity-references) | - | 2つ目のボディを提供する[`<pc-entity>`](../pc-entity)への参照。空にすると`entity-a`をワールド空間の固定点に拘束します |
 | `limits` | Vector2 | `"-45 45"` | 主軸まわりの回転または移動のリミット。「min max」で、`hinge`では度、`slider`ではユニットです |
 | `linear-damping` | Vector3 | `"1 1 1"` | 直線軸ごとのスプリングのダンピング。`6dof`で使用します |
 | `linear-equilibrium` | Vector3 | `"0 0 0"` | 直線スプリングの静止位置。`6dof`で使用します |

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-joint.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-joint.md
@@ -60,8 +60,8 @@ description: "pc-joint要素のリファレンス: fixed・ball・hinge・slider
 | `enable-collision` | Boolean | `"false"` | 拘束される2つのボディが互いに衝突するかどうか |
 | `enable-limits` | Boolean | `"false"` | ジョイントのリミットを適用するかどうか。これを設定するまでリミット系の属性は効果がありません |
 | `enabled` | Boolean | `"true"` | コンポーネントの有効状態 |
-| `entity-a` | String | - | 1つ目のボディを提供する[`<pc-entity>`](../pc-entity)への参照。[`<pc-rigid-body>`](../pc-rigid-body)が必要です |
-| `entity-b` | String | - | 2つ目のボディを提供する[`<pc-entity>`](../pc-entity)への参照。空にすると`entity-a`をワールド空間の固定点に拘束します |
+| `entity-a` | Entity Reference | - | 1つ目のボディを提供する[`<pc-entity>`](../pc-entity)への参照。[`<pc-rigid-body>`](../pc-rigid-body)が必要です |
+| `entity-b` | Entity Reference | - | 2つ目のボディを提供する[`<pc-entity>`](../pc-entity)への参照。空にすると`entity-a`をワールド空間の固定点に拘束します |
 | `limits` | Vector2 | `"-45 45"` | 主軸まわりの回転または移動のリミット。「min max」で、`hinge`では度、`slider`ではユニットです |
 | `linear-damping` | Vector3 | `"1 1 1"` | 直線軸ごとのスプリングのダンピング。`6dof`で使用します |
 | `linear-equilibrium` | Vector3 | `"0 0 0"` | 直線スプリングの静止位置。`6dof`で使用します |

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-material.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-material.md
@@ -28,7 +28,7 @@ description: "pc-material要素のリファレンス: カラー、メタルネ�
 | `alpha-test` | Number | `"0"` | アルファテストの参照値。不透明度がこの値を下回るフラグメントは破棄されます |
 | `alpha-to-coverage` | Boolean | `"false"` | マルチサンプリングで透明度を解決するアルファトゥカバレッジを使用するかどうか |
 | `ao-intensity` | Number | `"1"` | アンビエントオクルージョンマップの強さ（0〜1） |
-| `ao-map` | String | - | アンビエントオクルージョンマップとして使用するテクスチャ [`<pc-asset>`](../pc-asset) の `id` |
+| `ao-map` | Asset ID | - | アンビエントオクルージョンマップとして使用するテクスチャ [`<pc-asset>`](../pc-asset) の `id` |
 | `blend-type` | Enum | `"none"` | マテリアルを背後のシーンとブレンドする方法: `"none"` \| `"normal"` \| `"additive"` \| `"additive-alpha"` \| `"premultiplied"` \| `"multiplicative"` \| `"multiplicative-2x"` \| `"screen"` \| `"min"` \| `"max"` \| `"subtractive"` |
 | `bumpiness` | Number | `"1"` | ノーマルマップの強さ。0はフラット、1はマップの効果を最大に適用します |
 | `cull` | Enum | `"back"` | メッシュのどの面をカリングするか: `"none"` \| `"back"` \| `"front"` \| `"front-and-back"` |
@@ -36,30 +36,30 @@ description: "pc-material要素のリファレンス: カラー、メタルネ�
 | `depth-test` | Boolean | `"true"` | フラグメントを深度バッファに対してテストするかどうか |
 | `depth-write` | Boolean | `"true"` | フラグメントが深度バッファに書き込むかどうか |
 | `diffuse` | Color | `"1 1 1"` | マテリアルのディフューズカラー |
-| `diffuse-map` | String | - | ディフューズマップとして使用するテクスチャ [`<pc-asset>`](../pc-asset) の `id` |
+| `diffuse-map` | Asset ID | - | ディフューズマップとして使用するテクスチャ [`<pc-asset>`](../pc-asset) の `id` |
 | `emissive` | Color | `"0 0 0"` | マテリアルのエミッシブカラー |
 | `emissive-intensity` | Number | `"1"` | エミッシブカラーとマップに適用される乗数 |
-| `emissive-map` | String | - | エミッシブマップとして使用するテクスチャ [`<pc-asset>`](../pc-asset) の `id` |
+| `emissive-map` | Asset ID | - | エミッシブマップとして使用するテクスチャ [`<pc-asset>`](../pc-asset) の `id` |
 | `enable-ggx-specular` | Boolean | `"false"` | 異方性をサポートするGGXスペキュラモデルを使用するかどうか |
 | `fresnel-model` | Enum | `"schlick"` | 浅い角度でのスペキュラ反射に使用するフレネルモデル: `"none"` \| `"schlick"` |
 | `gloss` | Number | `"0.25"` | マテリアルの光沢度。0（ラフ）から1（光沢）まで。`roughness`も参照してください |
 | `gloss-invert` | Boolean | `"false"` | グロスの値とマップを反転し、ラフネスとして扱うかどうか。`roughness`または`roughness-map`を設定すると自動的に有効になります |
-| `gloss-map` | String | - | グロスマップとして使用するテクスチャ [`<pc-asset>`](../pc-asset) の `id` |
-| `height-map` | String | - | ハイトマップとして使用するテクスチャ [`<pc-asset>`](../pc-asset) の `id` |
+| `gloss-map` | Asset ID | - | グロスマップとして使用するテクスチャ [`<pc-asset>`](../pc-asset) の `id` |
+| `height-map` | Asset ID | - | ハイトマップとして使用するテクスチャ [`<pc-asset>`](../pc-asset) の `id` |
 | `height-map-factor` | Number | `"1"` | ハイトマップによる視差効果の強さ |
 | `id` | String | - | 他のタグがこのマテリアルを参照するために使用する一意の識別子 |
 | `metalness` | Number | `"0"` | 表面の金属度。0（誘電体）から1（金属）まで |
-| `metalness-map` | String | - | メタルネスマップとして使用するテクスチャ [`<pc-asset>`](../pc-asset) の `id` |
+| `metalness-map` | Asset ID | - | メタルネスマップとして使用するテクスチャ [`<pc-asset>`](../pc-asset) の `id` |
 | `name` | String | `"Untitled"` | マテリアルの名前。参照用ではなくラベルです。他のタグは常に`id`でマテリアルを指定します |
-| `normal-map` | String | - | ノーマルマップとして使用するテクスチャ [`<pc-asset>`](../pc-asset) の `id` |
+| `normal-map` | Asset ID | - | ノーマルマップとして使用するテクスチャ [`<pc-asset>`](../pc-asset) の `id` |
 | `occlude-direct` | Boolean | `"false"` | アンビエントオクルージョンが直接光も減衰させるかどうか |
 | `occlude-specular` | Enum | `"ao"` | スペキュラ反射をオクルージョンする方法: `"none"` \| `"ao"` \| `"gloss-dependent"` |
 | `opacity` | Number | `"1"` | マテリアルの不透明度。0（透明）から1（不透明）まで。視覚的な効果を得るには`"none"`以外の`blend-type`が必要です |
 | `opacity-dither` | Enum | `"none"` | ブレンドなしで透明度を近似する不透明度のディザリング: `"none"` \| `"bayer8"` \| `"bluenoise"` \| `"ignnoise"` |
 | `opacity-fades-specular` | Boolean | `"true"` | マテリアルが透明になるにつれてスペキュラハイライトをフェードアウトさせるかどうか |
-| `opacity-map` | String | - | オパシティマップとして使用するテクスチャ [`<pc-asset>`](../pc-asset) の `id` |
+| `opacity-map` | Asset ID | - | オパシティマップとして使用するテクスチャ [`<pc-asset>`](../pc-asset) の `id` |
 | `roughness` | Number | - | マテリアルのラフネス。0（光沢）から1（ラフ）まで。`gloss`のエイリアスで、`gloss-invert`も設定するため、`gloss`系の属性と組み合わせないでください |
-| `roughness-map` | String | - | ラフネスマップとして使用するテクスチャ [`<pc-asset>`](../pc-asset) の `id`。`gloss-map`のエイリアスで、`gloss-invert`も設定するため、`gloss`系の属性と組み合わせないでください |
+| `roughness-map` | Asset ID | - | ラフネスマップとして使用するテクスチャ [`<pc-asset>`](../pc-asset) の `id`。`gloss-map`のエイリアスで、`gloss-invert`も設定するため、`gloss`系の属性と組み合わせないでください |
 | `slope-depth-bias` | Number | `"0"` | 表面の傾きに比例して適用される深度オフセット。Zファイティングの解決に使用します |
 | `specular` | Color | `"0 0 0"` | マテリアルのスペキュラカラー。メタルネスワークフローが無効か、`use-metalness-specular-color`が有効な場合にのみ適用されます |
 | `specularity-factor` | Number | `"1"` | 正面の角度でのスペキュラ反射の強さ（0〜1）。`use-metalness-specular-color`が有効な場合にのみ適用されます |

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-material.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-material.md
@@ -28,7 +28,7 @@ description: "pc-material要素のリファレンス: カラー、メタルネ�
 | `alpha-test` | Number | `"0"` | アルファテストの参照値。不透明度がこの値を下回るフラグメントは破棄されます |
 | `alpha-to-coverage` | Boolean | `"false"` | マルチサンプリングで透明度を解決するアルファトゥカバレッジを使用するかどうか |
 | `ao-intensity` | Number | `"1"` | アンビエントオクルージョンマップの強さ（0〜1） |
-| `ao-map` | Asset ID | - | アンビエントオクルージョンマップとして使用するテクスチャ [`<pc-asset>`](../pc-asset) の `id` |
+| `ao-map` | [Asset ID](../attributes.md#asset-and-material-ids) | - | アンビエントオクルージョンマップとして使用するテクスチャ [`<pc-asset>`](../pc-asset) の `id` |
 | `blend-type` | Enum | `"none"` | マテリアルを背後のシーンとブレンドする方法: `"none"` \| `"normal"` \| `"additive"` \| `"additive-alpha"` \| `"premultiplied"` \| `"multiplicative"` \| `"multiplicative-2x"` \| `"screen"` \| `"min"` \| `"max"` \| `"subtractive"` |
 | `bumpiness` | Number | `"1"` | ノーマルマップの強さ。0はフラット、1はマップの効果を最大に適用します |
 | `cull` | Enum | `"back"` | メッシュのどの面をカリングするか: `"none"` \| `"back"` \| `"front"` \| `"front-and-back"` |
@@ -36,30 +36,30 @@ description: "pc-material要素のリファレンス: カラー、メタルネ�
 | `depth-test` | Boolean | `"true"` | フラグメントを深度バッファに対してテストするかどうか |
 | `depth-write` | Boolean | `"true"` | フラグメントが深度バッファに書き込むかどうか |
 | `diffuse` | Color | `"1 1 1"` | マテリアルのディフューズカラー |
-| `diffuse-map` | Asset ID | - | ディフューズマップとして使用するテクスチャ [`<pc-asset>`](../pc-asset) の `id` |
+| `diffuse-map` | [Asset ID](../attributes.md#asset-and-material-ids) | - | ディフューズマップとして使用するテクスチャ [`<pc-asset>`](../pc-asset) の `id` |
 | `emissive` | Color | `"0 0 0"` | マテリアルのエミッシブカラー |
 | `emissive-intensity` | Number | `"1"` | エミッシブカラーとマップに適用される乗数 |
-| `emissive-map` | Asset ID | - | エミッシブマップとして使用するテクスチャ [`<pc-asset>`](../pc-asset) の `id` |
+| `emissive-map` | [Asset ID](../attributes.md#asset-and-material-ids) | - | エミッシブマップとして使用するテクスチャ [`<pc-asset>`](../pc-asset) の `id` |
 | `enable-ggx-specular` | Boolean | `"false"` | 異方性をサポートするGGXスペキュラモデルを使用するかどうか |
 | `fresnel-model` | Enum | `"schlick"` | 浅い角度でのスペキュラ反射に使用するフレネルモデル: `"none"` \| `"schlick"` |
 | `gloss` | Number | `"0.25"` | マテリアルの光沢度。0（ラフ）から1（光沢）まで。`roughness`も参照してください |
 | `gloss-invert` | Boolean | `"false"` | グロスの値とマップを反転し、ラフネスとして扱うかどうか。`roughness`または`roughness-map`を設定すると自動的に有効になります |
-| `gloss-map` | Asset ID | - | グロスマップとして使用するテクスチャ [`<pc-asset>`](../pc-asset) の `id` |
-| `height-map` | Asset ID | - | ハイトマップとして使用するテクスチャ [`<pc-asset>`](../pc-asset) の `id` |
+| `gloss-map` | [Asset ID](../attributes.md#asset-and-material-ids) | - | グロスマップとして使用するテクスチャ [`<pc-asset>`](../pc-asset) の `id` |
+| `height-map` | [Asset ID](../attributes.md#asset-and-material-ids) | - | ハイトマップとして使用するテクスチャ [`<pc-asset>`](../pc-asset) の `id` |
 | `height-map-factor` | Number | `"1"` | ハイトマップによる視差効果の強さ |
 | `id` | String | - | 他のタグがこのマテリアルを参照するために使用する一意の識別子 |
 | `metalness` | Number | `"0"` | 表面の金属度。0（誘電体）から1（金属）まで |
-| `metalness-map` | Asset ID | - | メタルネスマップとして使用するテクスチャ [`<pc-asset>`](../pc-asset) の `id` |
+| `metalness-map` | [Asset ID](../attributes.md#asset-and-material-ids) | - | メタルネスマップとして使用するテクスチャ [`<pc-asset>`](../pc-asset) の `id` |
 | `name` | String | `"Untitled"` | マテリアルの名前。参照用ではなくラベルです。他のタグは常に`id`でマテリアルを指定します |
-| `normal-map` | Asset ID | - | ノーマルマップとして使用するテクスチャ [`<pc-asset>`](../pc-asset) の `id` |
+| `normal-map` | [Asset ID](../attributes.md#asset-and-material-ids) | - | ノーマルマップとして使用するテクスチャ [`<pc-asset>`](../pc-asset) の `id` |
 | `occlude-direct` | Boolean | `"false"` | アンビエントオクルージョンが直接光も減衰させるかどうか |
 | `occlude-specular` | Enum | `"ao"` | スペキュラ反射をオクルージョンする方法: `"none"` \| `"ao"` \| `"gloss-dependent"` |
 | `opacity` | Number | `"1"` | マテリアルの不透明度。0（透明）から1（不透明）まで。視覚的な効果を得るには`"none"`以外の`blend-type`が必要です |
 | `opacity-dither` | Enum | `"none"` | ブレンドなしで透明度を近似する不透明度のディザリング: `"none"` \| `"bayer8"` \| `"bluenoise"` \| `"ignnoise"` |
 | `opacity-fades-specular` | Boolean | `"true"` | マテリアルが透明になるにつれてスペキュラハイライトをフェードアウトさせるかどうか |
-| `opacity-map` | Asset ID | - | オパシティマップとして使用するテクスチャ [`<pc-asset>`](../pc-asset) の `id` |
+| `opacity-map` | [Asset ID](../attributes.md#asset-and-material-ids) | - | オパシティマップとして使用するテクスチャ [`<pc-asset>`](../pc-asset) の `id` |
 | `roughness` | Number | - | マテリアルのラフネス。0（光沢）から1（ラフ）まで。`gloss`のエイリアスで、`gloss-invert`も設定するため、`gloss`系の属性と組み合わせないでください |
-| `roughness-map` | Asset ID | - | ラフネスマップとして使用するテクスチャ [`<pc-asset>`](../pc-asset) の `id`。`gloss-map`のエイリアスで、`gloss-invert`も設定するため、`gloss`系の属性と組み合わせないでください |
+| `roughness-map` | [Asset ID](../attributes.md#asset-and-material-ids) | - | ラフネスマップとして使用するテクスチャ [`<pc-asset>`](../pc-asset) の `id`。`gloss-map`のエイリアスで、`gloss-invert`も設定するため、`gloss`系の属性と組み合わせないでください |
 | `slope-depth-bias` | Number | `"0"` | 表面の傾きに比例して適用される深度オフセット。Zファイティングの解決に使用します |
 | `specular` | Color | `"0 0 0"` | マテリアルのスペキュラカラー。メタルネスワークフローが無効か、`use-metalness-specular-color`が有効な場合にのみ適用されます |
 | `specularity-factor` | Number | `"1"` | 正面の角度でのスペキュラ反射の強さ（0〜1）。`use-metalness-specular-color`が有効な場合にのみ適用されます |

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-model.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-model.md
@@ -35,7 +35,7 @@ description: "pc-model要素のリファレンス: GLBコンテナアセット�
 
 | 属性 | タイプ | デフォルト | 説明 |
 | --- | --- | --- | --- |
-| `asset` | Asset ID | - | コンテナアセットID (`container`型のアセットを参照する必要があります) |
+| `asset` | [Asset ID](../attributes.md#asset-and-material-ids) | - | コンテナアセットID (`container`型のアセットを参照する必要があります) |
 | `enabled` | Boolean | `"true"` | モデルの有効状態 |
 | `name` | String | - | ホストエンティティの名前 |
 | `position` | Vector3 | `"0 0 0"` | ローカル空間の位置を "X Y Z" で指定 |

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-model.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-model.md
@@ -35,7 +35,7 @@ description: "pc-model要素のリファレンス: GLBコンテナアセット�
 
 | 属性 | タイプ | デフォルト | 説明 |
 | --- | --- | --- | --- |
-| `asset` | String | - | コンテナアセットID (`container`型のアセットを参照する必要があります) |
+| `asset` | Asset ID | - | コンテナアセットID (`container`型のアセットを参照する必要があります) |
 | `enabled` | Boolean | `"true"` | モデルの有効状態 |
 | `name` | String | - | ホストエンティティの名前 |
 | `position` | Vector3 | `"0 0 0"` | ローカル空間の位置を "X Y Z" で指定 |

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-particle-system.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-particle-system.md
@@ -17,7 +17,7 @@ description: "pc-particle-system要素のリファレンス: エミッター、�
 
 | 属性 | タイプ | デフォルト | 説明 |
 | --- | --- | --- | --- |
-| `asset` | Asset ID | - | パーティクルシステム設定を定義するJSONアセットID |
+| `asset` | [Asset ID](../attributes.md#asset-and-material-ids) | - | パーティクルシステム設定を定義するJSONアセットID |
 | `enabled` | Boolean | `"true"` | コンポーネントの有効状態 |
 
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-particle-system.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-particle-system.md
@@ -17,7 +17,7 @@ description: "pc-particle-system要素のリファレンス: エミッター、�
 
 | 属性 | タイプ | デフォルト | 説明 |
 | --- | --- | --- | --- |
-| `asset` | String | - | パーティクルシステム設定を定義するJSONアセットID |
+| `asset` | Asset ID | - | パーティクルシステム設定を定義するJSONアセットID |
 | `enabled` | Boolean | `"true"` | コンポーネントの有効状態 |
 
 </div>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-render.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-render.md
@@ -19,7 +19,7 @@ description: "pc-render要素のリファレンス: プリミティブ形状（�
 | --- | --- | --- | --- |
 | `cast-shadows` | Boolean | `"true"` | コンポーネントが影を落とすかどうか |
 | `enabled` | Boolean | `"true"` | コンポーネントの有効状態 |
-| `material` | Material ID | - | プリミティブのレンダリングに使用する [`<pc-material>`](../pc-material) の `id`。省略した場合はデフォルトのマテリアルが使用されます |
+| `material` | [Material ID](../attributes.md#asset-and-material-ids) | - | プリミティブのレンダリングに使用する [`<pc-material>`](../pc-material) の `id`。省略した場合はデフォルトのマテリアルが使用されます |
 | `receive-shadows` | Boolean | `"true"` | コンポーネントが影を受け取るかどうか |
 | `type` | Enum | `"box"` | レンダリングするプリミティブの形状: `"box"` \| `"capsule"` \| `"cone"` \| `"cylinder"` \| `"plane"` \| `"sphere"` |
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-render.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-render.md
@@ -19,7 +19,7 @@ description: "pc-render要素のリファレンス: プリミティブ形状（�
 | --- | --- | --- | --- |
 | `cast-shadows` | Boolean | `"true"` | コンポーネントが影を落とすかどうか |
 | `enabled` | Boolean | `"true"` | コンポーネントの有効状態 |
-| `material` | String | - | プリミティブのレンダリングに使用する [`<pc-material>`](../pc-material) の `id`。省略した場合はデフォルトのマテリアルが使用されます |
+| `material` | Material ID | - | プリミティブのレンダリングに使用する [`<pc-material>`](../pc-material) の `id`。省略した場合はデフォルトのマテリアルが使用されます |
 | `receive-shadows` | Boolean | `"true"` | コンポーネントが影を受け取るかどうか |
 | `type` | Enum | `"box"` | レンダリングするプリミティブの形状: `"box"` \| `"capsule"` \| `"cone"` \| `"cylinder"` \| `"plane"` \| `"sphere"` |
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-scroll-view.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-scroll-view.md
@@ -20,19 +20,19 @@ description: "pc-scroll-view要素のリファレンス: コンテンツ、ス�
 | 属性 | タイプ | デフォルト | 説明 |
 | --- | --- | --- | --- |
 | `bounce-amount` | Number | `"0.1"` | `scroll-mode="bounce"` のとき、コンテンツが範囲を超えてバウンスする量（0〜1） |
-| `content` | String | - | ビューのスクロールに合わせて移動するコンテンツ [`<pc-entity>`](../pc-entity) への参照 |
+| `content` | Entity Reference | - | ビューのスクロールに合わせて移動するコンテンツ [`<pc-entity>`](../pc-entity) への参照 |
 | `enabled` | Boolean | `"true"` | コンポーネントの有効状態 |
 | `friction` | Number | `"0.05"` | 投げられた後のコンテンツの動きやすさ（0 = なし、1 = 高い） |
 | `horizontal` | Boolean | `"true"` | 水平軸方向のスクロールを有効にするかどうか |
-| `horizontal-scrollbar` | String | - | 水平 [`<pc-scrollbar>`](../pc-scrollbar) を保持する [`<pc-entity>`](../pc-entity) への参照 |
+| `horizontal-scrollbar` | Entity Reference | - | 水平 [`<pc-scrollbar>`](../pc-scrollbar) を保持する [`<pc-entity>`](../pc-entity) への参照 |
 | `horizontal-scrollbar-visibility` | Enum | `"when-required"` | 水平スクロールバーを表示するタイミング: `"always"` \| `"when-required"` |
 | `mouse-wheel-sensitivity` | Vector2 | `"1 1"` | マウスホイールの感度を `x y` で指定（軸の値が0の場合、その軸のホイールスクロールは無効） |
 | `scroll-mode` | Enum | `"bounce"` | 範囲を超えてスクロールしたときの挙動: `"clamp"` \| `"bounce"` \| `"infinite"` |
 | `use-mouse-wheel` | Boolean | `"true"` | スクロールビューがマウスホイールに反応するかどうか |
 | `vertical` | Boolean | `"true"` | 垂直軸方向のスクロールを有効にするかどうか |
-| `vertical-scrollbar` | String | - | 垂直 [`<pc-scrollbar>`](../pc-scrollbar) を保持する [`<pc-entity>`](../pc-entity) への参照 |
+| `vertical-scrollbar` | Entity Reference | - | 垂直 [`<pc-scrollbar>`](../pc-scrollbar) を保持する [`<pc-entity>`](../pc-entity) への参照 |
 | `vertical-scrollbar-visibility` | Enum | `"when-required"` | 垂直スクロールバーを表示するタイミング: `"always"` \| `"when-required"` |
-| `viewport` | String | - | ビューポートとして使用される [`<pc-entity>`](../pc-entity) への参照。コンテンツをスクロールビューの範囲にクリップします |
+| `viewport` | Entity Reference | - | ビューポートとして使用される [`<pc-entity>`](../pc-entity) への参照。コンテンツをスクロールビューの範囲にクリップします |
 
 </div>
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-scroll-view.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-scroll-view.md
@@ -20,19 +20,19 @@ description: "pc-scroll-view要素のリファレンス: コンテンツ、ス�
 | 属性 | タイプ | デフォルト | 説明 |
 | --- | --- | --- | --- |
 | `bounce-amount` | Number | `"0.1"` | `scroll-mode="bounce"` のとき、コンテンツが範囲を超えてバウンスする量（0〜1） |
-| `content` | Entity Reference | - | ビューのスクロールに合わせて移動するコンテンツ [`<pc-entity>`](../pc-entity) への参照 |
+| `content` | [Entity Reference](../attributes.md#entity-references) | - | ビューのスクロールに合わせて移動するコンテンツ [`<pc-entity>`](../pc-entity) への参照 |
 | `enabled` | Boolean | `"true"` | コンポーネントの有効状態 |
 | `friction` | Number | `"0.05"` | 投げられた後のコンテンツの動きやすさ（0 = なし、1 = 高い） |
 | `horizontal` | Boolean | `"true"` | 水平軸方向のスクロールを有効にするかどうか |
-| `horizontal-scrollbar` | Entity Reference | - | 水平 [`<pc-scrollbar>`](../pc-scrollbar) を保持する [`<pc-entity>`](../pc-entity) への参照 |
+| `horizontal-scrollbar` | [Entity Reference](../attributes.md#entity-references) | - | 水平 [`<pc-scrollbar>`](../pc-scrollbar) を保持する [`<pc-entity>`](../pc-entity) への参照 |
 | `horizontal-scrollbar-visibility` | Enum | `"when-required"` | 水平スクロールバーを表示するタイミング: `"always"` \| `"when-required"` |
 | `mouse-wheel-sensitivity` | Vector2 | `"1 1"` | マウスホイールの感度を `x y` で指定（軸の値が0の場合、その軸のホイールスクロールは無効） |
 | `scroll-mode` | Enum | `"bounce"` | 範囲を超えてスクロールしたときの挙動: `"clamp"` \| `"bounce"` \| `"infinite"` |
 | `use-mouse-wheel` | Boolean | `"true"` | スクロールビューがマウスホイールに反応するかどうか |
 | `vertical` | Boolean | `"true"` | 垂直軸方向のスクロールを有効にするかどうか |
-| `vertical-scrollbar` | Entity Reference | - | 垂直 [`<pc-scrollbar>`](../pc-scrollbar) を保持する [`<pc-entity>`](../pc-entity) への参照 |
+| `vertical-scrollbar` | [Entity Reference](../attributes.md#entity-references) | - | 垂直 [`<pc-scrollbar>`](../pc-scrollbar) を保持する [`<pc-entity>`](../pc-entity) への参照 |
 | `vertical-scrollbar-visibility` | Enum | `"when-required"` | 垂直スクロールバーを表示するタイミング: `"always"` \| `"when-required"` |
-| `viewport` | Entity Reference | - | ビューポートとして使用される [`<pc-entity>`](../pc-entity) への参照。コンテンツをスクロールビューの範囲にクリップします |
+| `viewport` | [Entity Reference](../attributes.md#entity-references) | - | ビューポートとして使用される [`<pc-entity>`](../pc-entity) への参照。コンテンツをスクロールビューの範囲にクリップします |
 
 </div>
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-scrollbar.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-scrollbar.md
@@ -20,7 +20,7 @@ description: "pc-scrollbar要素のリファレンス: 向き、ハンドルサ�
 | 属性 | タイプ | デフォルト | 説明 |
 | --- | --- | --- | --- |
 | `enabled` | Boolean | `"true"` | コンポーネントの有効状態 |
-| `handle` | Entity Reference | - | ドラッグ可能なハンドルとして使用する [`<pc-entity>`](../pc-entity) への[参照](../attributes.md#entity-references)（エンティティの `name`、またはドキュメント全体の `#` セレクター） |
+| `handle` | [Entity Reference](../attributes.md#entity-references) | - | ドラッグ可能なハンドルとして使用する [`<pc-entity>`](../pc-entity) |
 | `handle-size` | Number | `"0.5"` | トラックのサイズに対するハンドルのサイズ（0〜1） |
 | `orientation` | Enum | `"horizontal"` | スクロールバーの向き: `"horizontal"` \| `"vertical"` |
 | `value` | Number | `"0"` | スクロールバーの現在位置（0〜1） |

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-scrollbar.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-scrollbar.md
@@ -20,7 +20,7 @@ description: "pc-scrollbar要素のリファレンス: 向き、ハンドルサ�
 | 属性 | タイプ | デフォルト | 説明 |
 | --- | --- | --- | --- |
 | `enabled` | Boolean | `"true"` | コンポーネントの有効状態 |
-| `handle` | String | - | ドラッグ可能なハンドルとして使用する [`<pc-entity>`](../pc-entity) への[参照](../attributes.md#entity-references)（エンティティの `name`、またはドキュメント全体の `#` セレクター） |
+| `handle` | Entity Reference | - | ドラッグ可能なハンドルとして使用する [`<pc-entity>`](../pc-entity) への[参照](../attributes.md#entity-references)（エンティティの `name`、またはドキュメント全体の `#` セレクター） |
 | `handle-size` | Number | `"0.5"` | トラックのサイズに対するハンドルのサイズ（0〜1） |
 | `orientation` | Enum | `"horizontal"` | スクロールバーの向き: `"horizontal"` \| `"vertical"` |
 | `value` | Number | `"0"` | スクロールバーの現在位置（0〜1） |

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-sky.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-sky.md
@@ -17,7 +17,7 @@ description: "pc-sky要素のリファレンス: テクスチャアセットに�
 
 | 属性 | タイプ | デフォルト | 説明 |
 | --- | --- | --- | --- |
-| `asset` | String | - | テクスチャアセットID (`texture`型のアセットを参照する必要があります) |
+| `asset` | Asset ID | - | テクスチャアセットID (`texture`型のアセットを参照する必要があります) |
 | `center` | Vector3 | `"0 0.01 0"` | "X Y Z"値としてのスカイの中心 (0-1の範囲) |
 | `intensity` | Number | `"1"` | スカイの明るさの強度 |
 | `lighting` | Boolean | `"false"` | スカイボックスを光源として使用するかどうか |

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-sky.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-sky.md
@@ -17,7 +17,7 @@ description: "pc-sky要素のリファレンス: テクスチャアセットに�
 
 | 属性 | タイプ | デフォルト | 説明 |
 | --- | --- | --- | --- |
-| `asset` | Asset ID | - | テクスチャアセットID (`texture`型のアセットを参照する必要があります) |
+| `asset` | [Asset ID](../attributes.md#asset-and-material-ids) | - | テクスチャアセットID (`texture`型のアセットを参照する必要があります) |
 | `center` | Vector3 | `"0 0.01 0"` | "X Y Z"値としてのスカイの中心 (0-1の範囲) |
 | `intensity` | Number | `"1"` | スカイの明るさの強度 |
 | `lighting` | Boolean | `"false"` | スカイボックスを光源として使用するかどうか |

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-sound-slot.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-sound-slot.md
@@ -17,7 +17,7 @@ description: "pc-sound-slot要素のリファレンス: 位置オーディオま
 
 | 属性 | タイプ | デフォルト | 説明 |
 | --- | --- | --- | --- |
-| `asset` | String | - | オーディオアセットID（`audio`型アセットを参照する必要があります） |
+| `asset` | Asset ID | - | オーディオアセットID（`audio`型アセットを参照する必要があります） |
 | `auto-play` | Boolean | `"false"` | サウンドが自動的に再生されるかどうか |
 | `duration` | Number | - | サウンドの再生時間（秒単位）（省略するとクリップ全体を再生します） |
 | `loop` | Boolean | `"false"` | サウンドがループするかどうか |

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-sound-slot.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-sound-slot.md
@@ -17,7 +17,7 @@ description: "pc-sound-slot要素のリファレンス: 位置オーディオま
 
 | 属性 | タイプ | デフォルト | 説明 |
 | --- | --- | --- | --- |
-| `asset` | Asset ID | - | オーディオアセットID（`audio`型アセットを参照する必要があります） |
+| `asset` | [Asset ID](../attributes.md#asset-and-material-ids) | - | オーディオアセットID（`audio`型アセットを参照する必要があります） |
 | `auto-play` | Boolean | `"false"` | サウンドが自動的に再生されるかどうか |
 | `duration` | Number | - | サウンドの再生時間（秒単位）（省略するとクリップ全体を再生します） |
 | `loop` | Boolean | `"false"` | サウンドがループするかどうか |

--- a/sidebars.js
+++ b/sidebars.js
@@ -515,7 +515,7 @@ const sidebars = {
         'user-manual/web-components/xr',
         {
           type: 'category',
-          label: 'Tags',
+          label: 'Tag Reference',
           link: {
             type: 'doc',
             id: 'user-manual/web-components/tags/index',

--- a/utils/check-web-components-manifest.mjs
+++ b/utils/check-web-components-manifest.mjs
@@ -72,6 +72,15 @@ const TYPE_VOCABULARY = new Set([
     'Asset ID', 'Material ID', 'Entity Reference'
 ]);
 
+// Types whose value grammar is defined on the Attributes page link there from the Type cell, so
+// the token itself answers "what do I write here". Every row of these types must carry exactly
+// this link, and no other type is linked.
+const TYPE_LINKS = {
+    'Asset ID': '../attributes.md#asset-and-material-ids',
+    'Material ID': '../attributes.md#asset-and-material-ids',
+    'Entity Reference': '../attributes.md#entity-references'
+};
+
 // Events a page documents by deferring to another page's table. The event name must still be
 // mentioned on the page; it just need not have a row of its own.
 const EVENTS_BY_REFERENCE = {
@@ -153,8 +162,11 @@ const splitRow = (line) => line.trim().slice(1, -1).split(/(?<!\\)\|/).map((cell
  * second-level heading whose first cell is a single backticked attribute name. Restricting the
  * scan to that section keeps the JavaScript Interface property tables out of the comparison.
  *
+ * A Type cell is either a bare token or a Markdown link around one; `type` is always the token
+ * and `typeLink` the link target, or null.
+ *
  * @param {string} markdown - The page source.
- * @returns {Map<string, { type: string, default: string, description: string }>} Rows by attribute.
+ * @returns {Map<string, { type: string, typeLink: string | null, default: string, description: string }>} Rows by attribute.
  */
 function parseAttributeTable(markdown) {
     const rows = new Map();
@@ -171,8 +183,10 @@ function parseAttributeTable(markdown) {
         if (cells.length < 4) {
             continue;
         }
+        const link = cells[1].match(/^\[([^\]]+)\]\(([^)]+)\)$/);
         rows.set(cells[0].replace(/`/g, ''), {
-            type: cells[1],
+            type: link ? link[1] : cells[1],
+            typeLink: link ? link[2] : null,
             default: cells[2].replace(/^`|`$/g, '').replace(/^"|"$/g, '').trim(),
             description: cells[3]
         });
@@ -338,7 +352,9 @@ for (const locale of LOCALES) {
         }
 
         // Rows the manifest knows nothing about are either read-once attributes on the allowlist or
-        // a rename the page has not followed. Allowlist entries with no row are reported too.
+        // a rename the page has not followed. Allowlist entries with no row are reported too. Every
+        // row's Type must come from the vocabulary, and link to the Attributes page exactly when the
+        // vocabulary says so.
         const readOnce = [...READ_ONCE['*'], ...(READ_ONCE[tag] ?? [])];
         for (const [name, row] of rows) {
             if (!declaredNames.has(name) && !readOnce.includes(name)) {
@@ -346,6 +362,10 @@ for (const locale of LOCALES) {
             }
             if (!TYPE_VOCABULARY.has(row.type)) {
                 report(locale.name, tag, `\`${name}\` type "${row.type}" is not in the Type vocabulary (${[...TYPE_VOCABULARY].join(', ')})`);
+            } else if (TYPE_LINKS[row.type] && row.typeLink !== TYPE_LINKS[row.type]) {
+                report(locale.name, tag, `\`${name}\` type ${row.type} must link to ${TYPE_LINKS[row.type]}`);
+            } else if (!TYPE_LINKS[row.type] && row.typeLink) {
+                report(locale.name, tag, `\`${name}\` type ${row.type} must not be a link`);
             }
         }
         for (const name of READ_ONCE[tag] ?? []) {

--- a/utils/check-web-components-manifest.mjs
+++ b/utils/check-web-components-manifest.mjs
@@ -65,6 +65,13 @@ const ALIAS_DEFAULTS = {
 // index and in Programmatic Access, rather than on each page.
 const SHARED_EVENTS = ['ready'];
 
+// The vocabulary of the Type column, defined under "The Type Column" in attributes.md. Every
+// row must use one of these, in every locale, so a translated or misspelt token is reported.
+const TYPE_VOCABULARY = new Set([
+    'Boolean', 'Number', 'Enum', 'String', 'Color', 'Vector2', 'Vector3', 'Vector4',
+    'Asset ID', 'Material ID', 'Entity Reference'
+]);
+
 // Events a page documents by deferring to another page's table. The event name must still be
 // mentioned on the page; it just need not have a row of its own.
 const EVENTS_BY_REFERENCE = {
@@ -333,9 +340,12 @@ for (const locale of LOCALES) {
         // Rows the manifest knows nothing about are either read-once attributes on the allowlist or
         // a rename the page has not followed. Allowlist entries with no row are reported too.
         const readOnce = [...READ_ONCE['*'], ...(READ_ONCE[tag] ?? [])];
-        for (const name of rows.keys()) {
+        for (const [name, row] of rows) {
             if (!declaredNames.has(name) && !readOnce.includes(name)) {
                 report(locale.name, tag, `attribute table has \`${name}\`, which the manifest does not declare`);
+            }
+            if (!TYPE_VOCABULARY.has(row.type)) {
+                report(locale.name, tag, `\`${name}\` type "${row.type}" is not in the Type vocabulary (${[...TYPE_VOCABULARY].join(', ')})`);
             }
         }
         for (const name of READ_ONCE[tag] ?? []) {


### PR DESCRIPTION
No linked issue. Third step of the tag reference improvements, after #1172 (fixes) and #1173 (the manifest check).

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/developer-site/blob/main/.github/CONTRIBUTING.md).

## What changed

**The tag index is restructured for readers.** [`tags/index.md`](docs/user-manual/web-components/tags/index.md) was a flat alphabetical table of 31 rows. It now reads in the order a newcomer needs:

1. **How the Tags Fit Together** — an HTML skeleton of the one shape every document has: `<pc-app>` holding resources and a `<pc-scene>`; entities holding one of each component tag; a `<pc-model>` with a `<pc-node>` inside it. The placement rules and the three entity-fronting tags follow it.
2. **Tags by Role** — eight small tables: Structure, Resources, Rendering, Animation, Physics, User Interface, Audio, Scripting. Several one-line descriptions were sharpened while moving them (`<pc-entity>` was "Defines an entity.").
3. **Shared Conventions** — the attribute contract, the component-naming note, repeatable children and the `ready` event, unchanged in substance.
4. **All Tags A–Z** — a compact one-line list, so the page still serves alphabetical lookup. The sidebar stays alphabetical.

**The sidebar category is renamed from "Tags" to "Tag Reference".** That is the page's own title and how the section landing page already links to it, and it is unambiguous on a site that also uses tags as a tutorial taxonomy. The Japanese sidebar already said タグリファレンス; its translation key is renamed to follow the new label, since Docusaurus keys sidebar translations by the label text.

**The Type column stops hiding references.** 56 rows were typed `String`, covering free text, asset ids and entity references alike. Three tokens now separate them, and each is a link to the section of the Attributes page that defines its grammar, so the token itself answers "what do I write here":

| Type | Rows | Meaning |
| --- | --- | --- |
| Asset ID | 22 | the `id` of a `<pc-asset>`: every `*asset*` attribute, the material's texture maps, the sprite `atlas` |
| Material ID | 1 | the `id` of a `<pc-material>`: `<pc-render>` `material` |
| Entity Reference | 8 | button `image`, joint `entity-a`/`entity-b`, scroll view `content`/`viewport`/scrollbars, scrollbar `handle` |

Linking the type replaces the inline "[Reference] (entity `name`, or document-wide `#` selector) to the…" that two of the eight Entity Reference rows carried and the other six did not; those two descriptions now just say what the reference is for. Primitive types stay unlinked: a column of identical blue `Number` tokens would carry no information.

[`attributes.md`](docs/user-manual/web-components/attributes.md) gains **The Type Column**, a legend mapping every token to its section, and a new **Asset and Material IDs** section. The behavior it states was checked in the library source: an id that matches no resource has no effect (`<pc-render>` keeps its default material; `MaterialElement.get()` returns `undefined` and the setter ignores it), and `<pc-model>` additionally logs a warning naming the asset.

**The manifest check enforces the vocabulary and the links.** `utils/check-web-components-manifest.mjs` now reports any Type cell outside the eleven tokens, any reference type whose cell does not link to its canonical section, and any other type that is linked — in both locales — so neither a translated token (#1173 found one) nor a stray link can land again.

**Japanese pages mirror every change**, including the skeleton's comments and the sharpened descriptions. Type tokens stay in English in the Japanese tables, as `Boolean` and `Vector3` already did, and link to the same anchors on the Japanese Attributes page.

## Verification

- `npm run check:web-components`: 31 tags, 664 rows, 56 events, clean, with the vocabulary and link rules.
- Negative test of the new rules on a scratch copy: an unlinked `Material ID`, an `Entity Reference` linked to the wrong section, and a linked `Boolean` are each reported by name.
- `npm run lint`: 0 issues in 1328 files.
- `npm run build`: both locales, no broken links or anchors. All twelve new heading ids resolve in en and ja, and every Type link resolves.
- Each of the 31 tags appears exactly once in the role tables of each locale.
- Rendered pages checked on a local `npm run serve`: the skeleton, the role tables, the A–Z list and the Attributes legend all render in both locales.

## Reviewer notes

- The group intro sentences (Physics needs Ammo; a screen hosts element-bearing entities) are the only new claims on the index beyond the descriptions; both are stated on the tag pages already.
- Nothing about the sidebar changes. Grouping it too would add a navigation level for a lookup index that works well alphabetically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
