### PR TITLE
docs: standardize the tail of every Web Components tag page

### DIFF
--- a/docs/user-manual/web-components/tags/pc-anim-clip.md
+++ b/docs/user-manual/web-components/tags/pc-anim-clip.md
@@ -147,3 +147,10 @@ document.querySelector('pc-anim').appendChild(clip);
 await clip.ready();
 document.querySelector('pc-anim').transition('wave');
 ```
+
+## See Also
+
+* [`<pc-anim>`](../pc-anim) — the component a clip belongs to
+* [`<pc-asset>`](../pc-asset) — the container or animation asset a clip's track comes from
+
+Examples: [Robot Arm](https://playcanvas.github.io/web-components/examples/robot-arm.html).

--- a/docs/user-manual/web-components/tags/pc-anim.md
+++ b/docs/user-manual/web-components/tags/pc-anim.md
@@ -193,3 +193,11 @@ console.log(anim.clips); // ['walk', 'stalk']
 ```
 
 Anything this element does not expose is available on `component` — the engine's [AnimComponent](https://api.playcanvas.com/engine/classes/AnimComponent.html) — including the playhead (`baseLayer.activeStateCurrentTime`), the active clip's duration, and state graphs and blend trees for animation beyond a flat set of clips.
+
+## See Also
+
+* [`<pc-anim-clip>`](../pc-anim-clip) — declares each clip the component plays
+* [`<pc-model>`](../pc-model) — the usual host, whose GLB supplies the animation tracks
+* [`<pc-asset>`](../pc-asset) — supplies clips from a separate GLB or animclip JSON
+
+Examples: [GLB Animation](https://playcanvas.github.io/web-components/examples/glb-animation.html) and [Robot Arm](https://playcanvas.github.io/web-components/examples/robot-arm.html).

--- a/docs/user-manual/web-components/tags/pc-app.md
+++ b/docs/user-manual/web-components/tags/pc-app.md
@@ -134,3 +134,12 @@ A complete application: a camera, a light and a sphere. Try setting `antialias="
 You can programmatically create and manipulate `<pc-app>` elements using the [AppElement API](https://api.playcanvas.com/web-components/classes/AppElement.html).
 
 The `app` property is the running engine [AppBase](https://api.playcanvas.com/engine/classes/AppBase.html) — `null` until the element is ready — which gives you the scene, the asset registry and the render loop; `elementFromEntity()` maps an engine entity back to the element that fronts it.
+
+## See Also
+
+* [`<pc-scene>`](../pc-scene) — the one scene an app renders
+* [`<pc-asset>`](../pc-asset) — resources the app preloads before the scene starts
+* [`<pc-wasm>`](../pc-wasm) — modules such as physics that the app loads before it boots
+* [Programmatic Access](../programmatic-access.md) — waiting for `ready` and reaching `app` from JavaScript
+
+Examples: [Spinning Cube](https://playcanvas.github.io/web-components/examples/spinning-cube.html) and [Basic Shapes](https://playcanvas.github.io/web-components/examples/basic-shapes.html).

--- a/docs/user-manual/web-components/tags/pc-app.md
+++ b/docs/user-manual/web-components/tags/pc-app.md
@@ -132,3 +132,5 @@ A complete application: a camera, a light and a sphere. Try setting `antialias="
 ## JavaScript Interface
 
 You can programmatically create and manipulate `<pc-app>` elements using the [AppElement API](https://api.playcanvas.com/web-components/classes/AppElement.html).
+
+The `app` property is the running engine [AppBase](https://api.playcanvas.com/engine/classes/AppBase.html) — `null` until the element is ready — which gives you the scene, the asset registry and the render loop; `elementFromEntity()` maps an engine entity back to the element that fronts it.

--- a/docs/user-manual/web-components/tags/pc-asset.md
+++ b/docs/user-manual/web-components/tags/pc-asset.md
@@ -142,3 +142,12 @@ Sprites are defined by a texture atlas (which holds the frame definitions) and o
 You can programmatically create and manipulate `<pc-asset>` elements using the [AssetElement API](https://api.playcanvas.com/web-components/classes/AssetElement.html).
 
 The `asset` property is the engine [Asset](https://api.playcanvas.com/engine/classes/Asset.html) the element registered — `null` until the element is ready — and `AssetElement.get(id)` looks one up by `id` without holding the element.
+
+## See Also
+
+* [`<pc-model>`](../pc-model) — instantiates a container asset
+* [`<pc-material>`](../pc-material) — takes texture assets for its maps
+* [`<pc-sound-slot>`](../pc-sound-slot) — plays an audio asset
+* [`<pc-script-instance>`](../pc-script-instance) — runs a script loaded as an asset
+
+Examples: [GLB Loader](https://playcanvas.github.io/web-components/examples/glb-loader.html), [Video Texture](https://playcanvas.github.io/web-components/examples/video-texture.html) and [Basic Sound](https://playcanvas.github.io/web-components/examples/basic-sound.html).

--- a/docs/user-manual/web-components/tags/pc-asset.md
+++ b/docs/user-manual/web-components/tags/pc-asset.md
@@ -140,3 +140,5 @@ Sprites are defined by a texture atlas (which holds the frame definitions) and o
 ## JavaScript Interface
 
 You can programmatically create and manipulate `<pc-asset>` elements using the [AssetElement API](https://api.playcanvas.com/web-components/classes/AssetElement.html).
+
+The `asset` property is the engine [Asset](https://api.playcanvas.com/engine/classes/Asset.html) the element registered — `null` until the element is ready — and `AssetElement.get(id)` looks one up by `id` without holding the element.

--- a/docs/user-manual/web-components/tags/pc-audio-listener.md
+++ b/docs/user-manual/web-components/tags/pc-audio-listener.md
@@ -77,3 +77,5 @@ The listener sits on the camera, and a sphere emitting positional footsteps circ
 ## JavaScript Interface
 
 You can programmatically create and manipulate `<pc-audio-listener>` elements using the [AudioListenerComponentElement API](https://api.playcanvas.com/web-components/classes/AudioListenerComponentElement.html).
+
+The `component` property is the engine [AudioListenerComponent](https://api.playcanvas.com/engine/classes/AudioListenerComponent.html) the element adds — `null` until the element is ready — and everything the attributes do not expose is available on it.

--- a/docs/user-manual/web-components/tags/pc-audio-listener.md
+++ b/docs/user-manual/web-components/tags/pc-audio-listener.md
@@ -79,3 +79,11 @@ The listener sits on the camera, and a sphere emitting positional footsteps circ
 You can programmatically create and manipulate `<pc-audio-listener>` elements using the [AudioListenerComponentElement API](https://api.playcanvas.com/web-components/classes/AudioListenerComponentElement.html).
 
 The `component` property is the engine [AudioListenerComponent](https://api.playcanvas.com/engine/classes/AudioListenerComponent.html) the element adds — `null` until the element is ready — and everything the attributes do not expose is available on it.
+
+## See Also
+
+* [`<pc-sound>`](../pc-sound) — the positional sound sources the listener hears
+* [`<pc-sound-slot>`](../pc-sound-slot) — the clips those sources play
+* [`<pc-camera>`](../pc-camera) — the listener usually rides on the camera entity
+
+Examples: [Positional Sound](https://playcanvas.github.io/web-components/examples/positional-sound.html).

--- a/docs/user-manual/web-components/tags/pc-button.md
+++ b/docs/user-manual/web-components/tags/pc-button.md
@@ -91,3 +91,11 @@ button.component.on('click', () => {
 You can programmatically create and manipulate `<pc-button>` elements using the [ButtonComponentElement API](https://api.playcanvas.com/web-components/classes/ButtonComponentElement.html).
 
 The `component` property is the engine [ButtonComponent](https://api.playcanvas.com/engine/classes/ButtonComponent.html) the element adds — `null` until the element is ready — and everything the attributes do not expose is available on it.
+
+## See Also
+
+* [`<pc-element>`](../pc-element) — the image element a button needs for input and transitions
+* [`<pc-screen>`](../pc-screen) — the screen the button's element hierarchy lives on
+* [`<pc-entity>`](../pc-entity) — click and pointer events on 3D objects, without a screen
+
+Examples: [UI Layout](https://playcanvas.github.io/web-components/examples/ui-layout.html) and [Scroll View](https://playcanvas.github.io/web-components/examples/scroll-view.html).

--- a/docs/user-manual/web-components/tags/pc-button.md
+++ b/docs/user-manual/web-components/tags/pc-button.md
@@ -89,3 +89,5 @@ button.component.on('click', () => {
 ## JavaScript Interface
 
 You can programmatically create and manipulate `<pc-button>` elements using the [ButtonComponentElement API](https://api.playcanvas.com/web-components/classes/ButtonComponentElement.html).
+
+The `component` property is the engine [ButtonComponent](https://api.playcanvas.com/engine/classes/ButtonComponent.html) the element adds — `null` until the element is ready — and everything the attributes do not expose is available on it.

--- a/docs/user-manual/web-components/tags/pc-camera.md
+++ b/docs/user-manual/web-components/tags/pc-camera.md
@@ -74,3 +74,12 @@ A row of boxes receding into the distance. Try a different `fov`, or switch to `
 You can programmatically create and manipulate `<pc-camera>` elements using the [CameraComponentElement API](https://api.playcanvas.com/web-components/classes/CameraComponentElement.html).
 
 The `component` property is the engine [CameraComponent](https://api.playcanvas.com/engine/classes/CameraComponent.html) the element adds — `null` until the element is ready — and everything the attributes do not expose is available on it.
+
+## See Also
+
+* [`<pc-scene>`](../pc-scene) — exposure and fog, which the camera's tone mapping works with
+* [`<pc-sky>`](../pc-sky) — a skybox in place of the clear color
+* [`<pc-script>`](../pc-script) — camera controls are engine scripts attached beside the camera
+* [XR Support](../xr.md) — entering VR and AR from the camera element
+
+Examples: [Basic Shapes](https://playcanvas.github.io/web-components/examples/basic-shapes.html) and [First Person Controller](https://playcanvas.github.io/web-components/examples/first-person-controller.html).

--- a/docs/user-manual/web-components/tags/pc-camera.md
+++ b/docs/user-manual/web-components/tags/pc-camera.md
@@ -72,3 +72,5 @@ A row of boxes receding into the distance. Try a different `fov`, or switch to `
 ## JavaScript Interface
 
 You can programmatically create and manipulate `<pc-camera>` elements using the [CameraComponentElement API](https://api.playcanvas.com/web-components/classes/CameraComponentElement.html).
+
+The `component` property is the engine [CameraComponent](https://api.playcanvas.com/engine/classes/CameraComponent.html) the element adds — `null` until the element is ready — and everything the attributes do not expose is available on it.

--- a/docs/user-manual/web-components/tags/pc-collision.md
+++ b/docs/user-manual/web-components/tags/pc-collision.md
@@ -89,3 +89,11 @@ Each collision shape matches its rendered shape: a sphere, a capsule and a box t
 You can programmatically create and manipulate `<pc-collision>` elements using the [CollisionComponentElement API](https://api.playcanvas.com/web-components/classes/CollisionComponentElement.html).
 
 The `component` property is the engine [CollisionComponent](https://api.playcanvas.com/engine/classes/CollisionComponent.html) the element adds — `null` until the element is ready — and everything the attributes do not expose is available on it.
+
+## See Also
+
+* [`<pc-rigid-body>`](../pc-rigid-body) — makes a collision shape take part in physics
+* [`<pc-joint>`](../pc-joint) — constrains two bodies that have collision shapes
+* [`<pc-wasm>`](../pc-wasm) — loads the Ammo module physics needs
+
+Examples: [Basic Physics](https://playcanvas.github.io/web-components/examples/basic-physics.html), [Physics Cluster](https://playcanvas.github.io/web-components/examples/physics-cluster.html) and [Ragdoll](https://playcanvas.github.io/web-components/examples/ragdoll.html).

--- a/docs/user-manual/web-components/tags/pc-collision.md
+++ b/docs/user-manual/web-components/tags/pc-collision.md
@@ -87,3 +87,5 @@ Each collision shape matches its rendered shape: a sphere, a capsule and a box t
 ## JavaScript Interface
 
 You can programmatically create and manipulate `<pc-collision>` elements using the [CollisionComponentElement API](https://api.playcanvas.com/web-components/classes/CollisionComponentElement.html).
+
+The `component` property is the engine [CollisionComponent](https://api.playcanvas.com/engine/classes/CollisionComponent.html) the element adds — `null` until the element is ready — and everything the attributes do not expose is available on it.

--- a/docs/user-manual/web-components/tags/pc-element.md
+++ b/docs/user-manual/web-components/tags/pc-element.md
@@ -91,3 +91,12 @@ An `image` element as a panel, with two `text` elements on top — the second us
 You can programmatically create and manipulate `<pc-element>` elements using the [ElementComponentElement API](https://api.playcanvas.com/web-components/classes/ElementComponentElement.html).
 
 The `component` property is the engine [ElementComponent](https://api.playcanvas.com/engine/classes/ElementComponent.html) the element adds — `null` until the element is ready — and everything the attributes do not expose is available on it.
+
+## See Also
+
+* [`<pc-screen>`](../pc-screen) — every element sits under a screen
+* [`<pc-button>`](../pc-button) — makes an image element interactive
+* [`<pc-layout-group>`](../pc-layout-group) — arranges sibling elements automatically
+* [`<pc-scroll-view>`](../pc-scroll-view) — scrolls a content element inside a viewport
+
+Examples: [2D Screen](https://playcanvas.github.io/web-components/examples/2d-screen.html), [Text](https://playcanvas.github.io/web-components/examples/text.html), [3D Text](https://playcanvas.github.io/web-components/examples/3d-text.html) and [UI Layout](https://playcanvas.github.io/web-components/examples/ui-layout.html).

--- a/docs/user-manual/web-components/tags/pc-element.md
+++ b/docs/user-manual/web-components/tags/pc-element.md
@@ -89,3 +89,5 @@ An `image` element as a panel, with two `text` elements on top — the second us
 ## JavaScript Interface
 
 You can programmatically create and manipulate `<pc-element>` elements using the [ElementComponentElement API](https://api.playcanvas.com/web-components/classes/ElementComponentElement.html).
+
+The `component` property is the engine [ElementComponent](https://api.playcanvas.com/engine/classes/ElementComponent.html) the element adds — `null` until the element is ready — and everything the attributes do not expose is available on it.

--- a/docs/user-manual/web-components/tags/pc-entity.md
+++ b/docs/user-manual/web-components/tags/pc-entity.md
@@ -98,3 +98,12 @@ You can programmatically create and manipulate `<pc-entity>` elements using the 
 The `entity` property is the engine [Entity](https://api.playcanvas.com/engine/classes/Entity.html) the element creates — `null` until the element is ready — so anything the attributes do not cover, from `lookAt()` to the components that child tags added, is reached through it.
 
 To stamp out many copies of an entity subtree, declare it once inside a native `<template>` element and clone it — see [Reusable Scenes with Templates](../templates.md).
+
+## See Also
+
+* [`<pc-model>`](../pc-model) — an entity that instantiates a GLB
+* [`<pc-node>`](../pc-node) — an entity inside a loaded model, addressed by name
+* [`<pc-script>`](../pc-script) — behavior attached to an entity
+* [Reusable Scenes with Templates](../templates.md) — cloning entity subtrees from a `<template>`
+
+Examples: [Basic Shapes](https://playcanvas.github.io/web-components/examples/basic-shapes.html) and [Falling Blocks](https://playcanvas.github.io/web-components/examples/falling-blocks.html).

--- a/docs/user-manual/web-components/tags/pc-entity.md
+++ b/docs/user-manual/web-components/tags/pc-entity.md
@@ -95,4 +95,6 @@ Entity transforms compose down the hierarchy: the small cube is a *child* of the
 
 You can programmatically create and manipulate `<pc-entity>` elements using the [EntityElement API](https://api.playcanvas.com/web-components/classes/EntityElement.html).
 
+The `entity` property is the engine [Entity](https://api.playcanvas.com/engine/classes/Entity.html) the element creates — `null` until the element is ready — so anything the attributes do not cover, from `lookAt()` to the components that child tags added, is reached through it.
+
 To stamp out many copies of an entity subtree, declare it once inside a native `<template>` element and clone it — see [Reusable Scenes with Templates](../templates.md).

--- a/docs/user-manual/web-components/tags/pc-gsplat.md
+++ b/docs/user-manual/web-components/tags/pc-gsplat.md
@@ -55,4 +55,6 @@ A Gaussian splat scanned from a real toy. Drag to orbit and scroll to zoom — a
 
 You can programmatically create and manipulate `<pc-gsplat>` elements using the [GSplatComponentElement API](https://api.playcanvas.com/web-components/classes/GSplatComponentElement.html).
 
+The `component` property is the engine [GSplatComponent](https://api.playcanvas.com/engine/classes/GSplatComponent.html) the element adds — `null` until the element is ready — and everything the attributes do not expose is available on it.
+
 The examples cover a few splat workflows: [Basic Splat](https://playcanvas.github.io/web-components/examples/basic-splat.html), [Splat Annotations](https://playcanvas.github.io/web-components/examples/splat-annotations.html), [Splat Flipbook](https://playcanvas.github.io/web-components/examples/splat-flipbook.html) and [Splat Streaming](https://playcanvas.github.io/web-components/examples/splat-streaming.html).

--- a/docs/user-manual/web-components/tags/pc-gsplat.md
+++ b/docs/user-manual/web-components/tags/pc-gsplat.md
@@ -57,4 +57,10 @@ You can programmatically create and manipulate `<pc-gsplat>` elements using the 
 
 The `component` property is the engine [GSplatComponent](https://api.playcanvas.com/engine/classes/GSplatComponent.html) the element adds — `null` until the element is ready — and everything the attributes do not expose is available on it.
 
-The examples cover a few splat workflows: [Basic Splat](https://playcanvas.github.io/web-components/examples/basic-splat.html), [Splat Annotations](https://playcanvas.github.io/web-components/examples/splat-annotations.html), [Splat Flipbook](https://playcanvas.github.io/web-components/examples/splat-flipbook.html) and [Splat Streaming](https://playcanvas.github.io/web-components/examples/splat-streaming.html).
+## See Also
+
+* [`<pc-asset>`](../pc-asset) — the splat file, declared as a `gsplat` asset
+* [`<pc-app>`](../pc-app) — the device settings recommended for splats
+* [Using Web Components](../../gaussian-splatting/building/your-first-app/web-components.md) — a first splat app, step by step
+
+Examples: [Basic Splat](https://playcanvas.github.io/web-components/examples/basic-splat.html), [Splat Annotations](https://playcanvas.github.io/web-components/examples/splat-annotations.html), [Splat Flipbook](https://playcanvas.github.io/web-components/examples/splat-flipbook.html) and [Splat Streaming](https://playcanvas.github.io/web-components/examples/splat-streaming.html).

--- a/docs/user-manual/web-components/tags/pc-joint.md
+++ b/docs/user-manual/web-components/tags/pc-joint.md
@@ -176,6 +176,8 @@ The [Physics Joints example](https://playcanvas.github.io/web-components/example
 
 You can programmatically create and manipulate `<pc-joint>` elements using the [JointComponentElement API](https://api.playcanvas.com/web-components/classes/JointComponentElement.html).
 
+The `component` property is the engine [JointComponent](https://api.playcanvas.com/engine/classes/JointComponent.html) the element adds — `null` until the element is ready — and everything the attributes do not expose is available on it.
+
 `entity-a` and `entity-b` resolve when they are set, so an entity created later is not picked up on its own — set the attribute again once it exists:
 
 ```javascript

--- a/docs/user-manual/web-components/tags/pc-joint.md
+++ b/docs/user-manual/web-components/tags/pc-joint.md
@@ -186,3 +186,11 @@ joint.entityA = '#link-3'; // re-resolves now
 ```
 
 Both accept the same reference forms as other entity-valued attributes — an entity `name` (resolved against the nearest enclosing entity first), or a document-wide `#` selector. See [Entity References](../attributes.md#entity-references).
+
+## See Also
+
+* [`<pc-rigid-body>`](../pc-rigid-body) — both constrained entities need one
+* [`<pc-collision>`](../pc-collision) — gives a body its shape
+* [`<pc-wasm>`](../pc-wasm) — loads the Ammo module physics needs
+
+Examples: [Physics Joints](https://playcanvas.github.io/web-components/examples/physics-joints.html), [Ragdoll](https://playcanvas.github.io/web-components/examples/ragdoll.html) and [AR Wiener Storm](https://playcanvas.github.io/web-components/examples/ar-wiener-storm.html).

--- a/docs/user-manual/web-components/tags/pc-layout-child.md
+++ b/docs/user-manual/web-components/tags/pc-layout-child.md
@@ -67,3 +67,5 @@ Three items in a horizontal group with `width-fitting="stretch"`. The middle ite
 ## JavaScript Interface
 
 You can programmatically create and manipulate `<pc-layout-child>` elements using the [LayoutChildComponentElement API](https://api.playcanvas.com/web-components/classes/LayoutChildComponentElement.html).
+
+The `component` property is the engine [LayoutChildComponent](https://api.playcanvas.com/engine/classes/LayoutChildComponent.html) the element adds — `null` until the element is ready — and everything the attributes do not expose is available on it.

--- a/docs/user-manual/web-components/tags/pc-layout-child.md
+++ b/docs/user-manual/web-components/tags/pc-layout-child.md
@@ -69,3 +69,10 @@ Three items in a horizontal group with `width-fitting="stretch"`. The middle ite
 You can programmatically create and manipulate `<pc-layout-child>` elements using the [LayoutChildComponentElement API](https://api.playcanvas.com/web-components/classes/LayoutChildComponentElement.html).
 
 The `component` property is the engine [LayoutChildComponent](https://api.playcanvas.com/engine/classes/LayoutChildComponent.html) the element adds — `null` until the element is ready — and everything the attributes do not expose is available on it.
+
+## See Also
+
+* [`<pc-layout-group>`](../pc-layout-group) — the group whose layout the child adjusts
+* [`<pc-element>`](../pc-element) — the element the child sizes
+
+Examples: [UI Layout](https://playcanvas.github.io/web-components/examples/ui-layout.html) and [Scroll View](https://playcanvas.github.io/web-components/examples/scroll-view.html).

--- a/docs/user-manual/web-components/tags/pc-layout-group.md
+++ b/docs/user-manual/web-components/tags/pc-layout-group.md
@@ -69,4 +69,10 @@ You can programmatically create and manipulate `<pc-layout-group>` elements usin
 
 The `component` property is the engine [LayoutGroupComponent](https://api.playcanvas.com/engine/classes/LayoutGroupComponent.html) the element adds — `null` until the element is ready — and everything the attributes do not expose is available on it.
 
-The [UI Layout example](https://playcanvas.github.io/web-components/examples/ui-layout.html) builds a nested set of layout groups on a world-space screen.
+## See Also
+
+* [`<pc-layout-child>`](../pc-layout-child) — per-child sizing rules
+* [`<pc-element>`](../pc-element) — the elements being arranged
+* [`<pc-screen>`](../pc-screen) — the screen the layout lives on
+
+Examples: [UI Layout](https://playcanvas.github.io/web-components/examples/ui-layout.html) and [Scroll View](https://playcanvas.github.io/web-components/examples/scroll-view.html).

--- a/docs/user-manual/web-components/tags/pc-layout-group.md
+++ b/docs/user-manual/web-components/tags/pc-layout-group.md
@@ -67,4 +67,6 @@ A vertical list that lays out its rows automatically. Try `orientation="horizont
 
 You can programmatically create and manipulate `<pc-layout-group>` elements using the [LayoutGroupComponentElement API](https://api.playcanvas.com/web-components/classes/LayoutGroupComponentElement.html).
 
+The `component` property is the engine [LayoutGroupComponent](https://api.playcanvas.com/engine/classes/LayoutGroupComponent.html) the element adds — `null` until the element is ready — and everything the attributes do not expose is available on it.
+
 The [UI Layout example](https://playcanvas.github.io/web-components/examples/ui-layout.html) builds a nested set of layout groups on a world-space screen.

--- a/docs/user-manual/web-components/tags/pc-light.md
+++ b/docs/user-manual/web-components/tags/pc-light.md
@@ -109,3 +109,11 @@ Try editing the light `color`, `intensity` or `type` values and watch the scene 
 You can programmatically create and manipulate `<pc-light>` elements using the [LightComponentElement API](https://api.playcanvas.com/web-components/classes/LightComponentElement.html).
 
 The `component` property is the engine [LightComponent](https://api.playcanvas.com/engine/classes/LightComponent.html) the element adds — `null` until the element is ready — and everything the attributes do not expose is available on it.
+
+## See Also
+
+* [`<pc-scene>`](../pc-scene) — exposure, which scales every light's contribution
+* [`<pc-sky>`](../pc-sky) — image-based lighting to fill in what direct lights miss
+* [`<pc-render>`](../pc-render) — `cast-shadows` and `receive-shadows` on what the light hits
+
+Examples: [Basic Shapes](https://playcanvas.github.io/web-components/examples/basic-shapes.html) and [Shadow Cascades](https://playcanvas.github.io/web-components/examples/shadow-cascades.html).

--- a/docs/user-manual/web-components/tags/pc-light.md
+++ b/docs/user-manual/web-components/tags/pc-light.md
@@ -107,3 +107,5 @@ Try editing the light `color`, `intensity` or `type` values and watch the scene 
 ## JavaScript Interface
 
 You can programmatically create and manipulate `<pc-light>` elements using the [LightComponentElement API](https://api.playcanvas.com/web-components/classes/LightComponentElement.html).
+
+The `component` property is the engine [LightComponent](https://api.playcanvas.com/engine/classes/LightComponent.html) the element adds — `null` until the element is ready — and everything the attributes do not expose is available on it.

--- a/docs/user-manual/web-components/tags/pc-material.md
+++ b/docs/user-manual/web-components/tags/pc-material.md
@@ -141,3 +141,11 @@ The `name` attribute is worth setting on any material you expect to identify lat
 You can programmatically create and manipulate `<pc-material>` elements using the [MaterialElement API](https://api.playcanvas.com/web-components/classes/MaterialElement.html).
 
 The `material` property is the engine [StandardMaterial](https://api.playcanvas.com/engine/classes/StandardMaterial.html) the element builds, and `MaterialElement.get(id)` looks one up by `id`. The element is synchronous, so neither waits on readiness.
+
+## See Also
+
+* [`<pc-render>`](../pc-render) — applies a material to a primitive
+* [`<pc-node>`](../pc-node) — overrides materials inside a loaded model
+* [`<pc-asset>`](../pc-asset) — the texture assets a material's maps reference
+
+Examples: [Basic Shapes](https://playcanvas.github.io/web-components/examples/basic-shapes.html), [Falling Blocks](https://playcanvas.github.io/web-components/examples/falling-blocks.html) and [Car Configurator](https://playcanvas.github.io/web-components/examples/car-configurator.html).

--- a/docs/user-manual/web-components/tags/pc-material.md
+++ b/docs/user-manual/web-components/tags/pc-material.md
@@ -139,3 +139,5 @@ The `name` attribute is worth setting on any material you expect to identify lat
 ## JavaScript Interface
 
 You can programmatically create and manipulate `<pc-material>` elements using the [MaterialElement API](https://api.playcanvas.com/web-components/classes/MaterialElement.html).
+
+The `material` property is the engine [StandardMaterial](https://api.playcanvas.com/engine/classes/StandardMaterial.html) the element builds, and `MaterialElement.get(id)` looks one up by `id`. The element is synchronous, so neither waits on readiness.

--- a/docs/user-manual/web-components/tags/pc-model.md
+++ b/docs/user-manual/web-components/tags/pc-model.md
@@ -198,3 +198,12 @@ Each line is a node: its name, then `[index]` when other nodes share that name, 
 The material `name` values are runtime labels read as they stand, which makes them a convenient handle but not a unique one: an unnamed glTF material is called `Untitled`, a primitive authored without a material carries the engine's shared `defaultGlbMaterial`, duplicates stay duplicated, and the name is `null` if a script cleared the assignment. The `index` is the unambiguous one. Both are what [`<pc-node>`'s `material-overrides`](../pc-node#overriding-materials) selects with, and a [`<pc-material>`](../pc-material) you swap in reports whatever its `name` attribute says — worth setting on any material you want to recognize here.
 
 The tree is a snapshot, computed afresh on each call: it does not track later changes to the hierarchy, and mutating it changes nothing. Being plain data, it survives `JSON.stringify`, so it is easy to log, diff or assert against in a test.
+
+## See Also
+
+* [`<pc-asset>`](../pc-asset) — the container asset a model instantiates
+* [`<pc-node>`](../pc-node) — reaches into the instantiated hierarchy
+* [`<pc-anim>`](../pc-anim) — plays the animations the GLB carries
+* [Loading Models](../loading-models.md) — loading a model and adjusting it from markup
+
+Examples: [GLB Loader](https://playcanvas.github.io/web-components/examples/glb-loader.html), [GLB Animation](https://playcanvas.github.io/web-components/examples/glb-animation.html) and [Product Viewer](https://playcanvas.github.io/web-components/examples/product-viewer.html).

--- a/docs/user-manual/web-components/tags/pc-node.md
+++ b/docs/user-manual/web-components/tags/pc-node.md
@@ -152,3 +152,12 @@ body.materialOverrides = null; // back to the authored materials
 ```
 
 The element stores a frozen copy of what you assign, so mutating your object afterwards changes nothing — assign a new mapping to change one. Property writes do not reflect back to the `material-overrides` attribute, which follows how the other override properties behave.
+
+## See Also
+
+* [`<pc-model>`](../pc-model) — the model whose node is bound
+* [`<pc-material>`](../pc-material) — materials a node can substitute via `material-overrides`
+* [`<pc-entity>`](../pc-entity) — attaches new content under a node
+* [Loading Models](../loading-models.md) — finding the nodes inside a loaded model
+
+Examples: [Product Viewer](https://playcanvas.github.io/web-components/examples/product-viewer.html), [Ragdoll](https://playcanvas.github.io/web-components/examples/ragdoll.html) and [Vehicle Physics](https://playcanvas.github.io/web-components/examples/vehicle-physics.html).

--- a/docs/user-manual/web-components/tags/pc-particle-system.md
+++ b/docs/user-manual/web-components/tags/pc-particle-system.md
@@ -84,3 +84,5 @@ Then add the particle system to your scene in HTML. This runs the `snow.json` ab
 ## JavaScript Interface
 
 You can programmatically create and manipulate `<pc-particle-system>` elements using the [ParticleSystemComponentElement API](https://api.playcanvas.com/web-components/classes/ParticleSystemComponentElement.html).
+
+The `component` property is the engine [ParticleSystemComponent](https://api.playcanvas.com/engine/classes/ParticleSystemComponent.html) the element adds — `null` until the element is ready — and everything the attributes do not expose is available on it.

--- a/docs/user-manual/web-components/tags/pc-particle-system.md
+++ b/docs/user-manual/web-components/tags/pc-particle-system.md
@@ -86,3 +86,10 @@ Then add the particle system to your scene in HTML. This runs the `snow.json` ab
 You can programmatically create and manipulate `<pc-particle-system>` elements using the [ParticleSystemComponentElement API](https://api.playcanvas.com/web-components/classes/ParticleSystemComponentElement.html).
 
 The `component` property is the engine [ParticleSystemComponent](https://api.playcanvas.com/engine/classes/ParticleSystemComponent.html) the element adds — `null` until the element is ready — and everything the attributes do not expose is available on it.
+
+## See Also
+
+* [`<pc-asset>`](../pc-asset) — the JSON configuration and the textures it names
+* [`<pc-entity>`](../pc-entity) — positions and orients the emitter
+
+Examples: [Basic Particles](https://playcanvas.github.io/web-components/examples/basic-particles.html).

--- a/docs/user-manual/web-components/tags/pc-render.md
+++ b/docs/user-manual/web-components/tags/pc-render.md
@@ -71,3 +71,12 @@ All six primitive shapes. Try changing any `type`, or add `material` once you ha
 You can programmatically create and manipulate `<pc-render>` elements using the [RenderComponentElement API](https://api.playcanvas.com/web-components/classes/RenderComponentElement.html).
 
 The `component` property is the engine [RenderComponent](https://api.playcanvas.com/engine/classes/RenderComponent.html) the element adds — `null` until the element is ready — and everything the attributes do not expose is available on it.
+
+## See Also
+
+* [`<pc-material>`](../pc-material) — the material a primitive is drawn with
+* [`<pc-model>`](../pc-model) — renders a GLB instead of a primitive
+* [`<pc-light>`](../pc-light) — lights and shadows the primitive
+* [`<pc-collision>`](../pc-collision) — a matching physics shape
+
+Examples: [Basic Shapes](https://playcanvas.github.io/web-components/examples/basic-shapes.html), [Falling Blocks](https://playcanvas.github.io/web-components/examples/falling-blocks.html) and [Physics Joints](https://playcanvas.github.io/web-components/examples/physics-joints.html).

--- a/docs/user-manual/web-components/tags/pc-render.md
+++ b/docs/user-manual/web-components/tags/pc-render.md
@@ -69,3 +69,5 @@ All six primitive shapes. Try changing any `type`, or add `material` once you ha
 ## JavaScript Interface
 
 You can programmatically create and manipulate `<pc-render>` elements using the [RenderComponentElement API](https://api.playcanvas.com/web-components/classes/RenderComponentElement.html).
+
+The `component` property is the engine [RenderComponent](https://api.playcanvas.com/engine/classes/RenderComponent.html) the element adds — `null` until the element is ready — and everything the attributes do not expose is available on it.

--- a/docs/user-manual/web-components/tags/pc-rigid-body.md
+++ b/docs/user-manual/web-components/tags/pc-rigid-body.md
@@ -76,4 +76,11 @@ You can programmatically create and manipulate `<pc-rigid-body>` elements using 
 
 The `component` property is the engine [RigidBodyComponent](https://api.playcanvas.com/engine/classes/RigidBodyComponent.html) the element adds — `null` until the element is ready — and everything the attributes do not expose is available on it.
 
-The physics examples build on this tag: [Basic Physics](https://playcanvas.github.io/web-components/examples/basic-physics.html), [Physics Cluster](https://playcanvas.github.io/web-components/examples/physics-cluster.html), [Physics Joints](https://playcanvas.github.io/web-components/examples/physics-joints.html), [Ragdoll](https://playcanvas.github.io/web-components/examples/ragdoll.html) and [Vehicle Physics](https://playcanvas.github.io/web-components/examples/vehicle-physics.html).
+## See Also
+
+* [`<pc-collision>`](../pc-collision) — the shape the body collides with; every rigid body needs one
+* [`<pc-joint>`](../pc-joint) — constrains two bodies together
+* [`<pc-wasm>`](../pc-wasm) — loads the Ammo module physics needs
+* [`<pc-scene>`](../pc-scene) — gravity
+
+Examples: [Basic Physics](https://playcanvas.github.io/web-components/examples/basic-physics.html), [Physics Cluster](https://playcanvas.github.io/web-components/examples/physics-cluster.html), [Ragdoll](https://playcanvas.github.io/web-components/examples/ragdoll.html) and [Vehicle Physics](https://playcanvas.github.io/web-components/examples/vehicle-physics.html).

--- a/docs/user-manual/web-components/tags/pc-rigid-body.md
+++ b/docs/user-manual/web-components/tags/pc-rigid-body.md
@@ -74,4 +74,6 @@ Dynamic bodies falling onto a static ground. The sphere has `restitution="0.9"`,
 
 You can programmatically create and manipulate `<pc-rigid-body>` elements using the [RigidBodyComponentElement API](https://api.playcanvas.com/web-components/classes/RigidBodyComponentElement.html).
 
+The `component` property is the engine [RigidBodyComponent](https://api.playcanvas.com/engine/classes/RigidBodyComponent.html) the element adds — `null` until the element is ready — and everything the attributes do not expose is available on it.
+
 The physics examples build on this tag: [Basic Physics](https://playcanvas.github.io/web-components/examples/basic-physics.html), [Physics Cluster](https://playcanvas.github.io/web-components/examples/physics-cluster.html), [Physics Joints](https://playcanvas.github.io/web-components/examples/physics-joints.html), [Ragdoll](https://playcanvas.github.io/web-components/examples/ragdoll.html) and [Vehicle Physics](https://playcanvas.github.io/web-components/examples/vehicle-physics.html).

--- a/docs/user-manual/web-components/tags/pc-scene.md
+++ b/docs/user-manual/web-components/tags/pc-scene.md
@@ -62,3 +62,5 @@ Boxes fading into linear fog. Try a different `fog-color` (match the camera's `c
 ## JavaScript Interface
 
 You can programmatically create and manipulate `<pc-scene>` elements using the [SceneElement API](https://api.playcanvas.com/web-components/classes/SceneElement.html).
+
+The `scene` property is the engine [Scene](https://api.playcanvas.com/engine/classes/Scene.html) — `null` until the element is ready — where fog, exposure and the sky are configured.

--- a/docs/user-manual/web-components/tags/pc-scene.md
+++ b/docs/user-manual/web-components/tags/pc-scene.md
@@ -64,3 +64,12 @@ Boxes fading into linear fog. Try a different `fog-color` (match the camera's `c
 You can programmatically create and manipulate `<pc-scene>` elements using the [SceneElement API](https://api.playcanvas.com/web-components/classes/SceneElement.html).
 
 The `scene` property is the engine [Scene](https://api.playcanvas.com/engine/classes/Scene.html) — `null` until the element is ready — where fog, exposure and the sky are configured.
+
+## See Also
+
+* [`<pc-app>`](../pc-app) — the application that holds the scene
+* [`<pc-sky>`](../pc-sky) — the scene's skybox and image-based lighting
+* [`<pc-camera>`](../pc-camera) — tone mapping, applied after the scene's exposure
+* [`<pc-rigid-body>`](../pc-rigid-body) — the bodies gravity acts on
+
+Examples: [Basic Shapes](https://playcanvas.github.io/web-components/examples/basic-shapes.html) and [Spinning Cube](https://playcanvas.github.io/web-components/examples/spinning-cube.html).

--- a/docs/user-manual/web-components/tags/pc-screen.md
+++ b/docs/user-manual/web-components/tags/pc-screen.md
@@ -62,3 +62,5 @@ A screen-space screen hosting a text element. With `scale-mode="blend"`, the UI 
 ## JavaScript Interface
 
 You can programmatically create and manipulate `<pc-screen>` elements using the [ScreenComponentElement API](https://api.playcanvas.com/web-components/classes/ScreenComponentElement.html).
+
+The `component` property is the engine [ScreenComponent](https://api.playcanvas.com/engine/classes/ScreenComponent.html) the element adds — `null` until the element is ready — and everything the attributes do not expose is available on it.

--- a/docs/user-manual/web-components/tags/pc-screen.md
+++ b/docs/user-manual/web-components/tags/pc-screen.md
@@ -64,3 +64,12 @@ A screen-space screen hosting a text element. With `scale-mode="blend"`, the UI 
 You can programmatically create and manipulate `<pc-screen>` elements using the [ScreenComponentElement API](https://api.playcanvas.com/web-components/classes/ScreenComponentElement.html).
 
 The `component` property is the engine [ScreenComponent](https://api.playcanvas.com/engine/classes/ScreenComponent.html) the element adds — `null` until the element is ready — and everything the attributes do not expose is available on it.
+
+## See Also
+
+* [`<pc-element>`](../pc-element) — the elements a screen renders
+* [`<pc-layout-group>`](../pc-layout-group) — automatic arrangement of elements
+* [`<pc-scroll-view>`](../pc-scroll-view) — scrolling content on a screen
+* [`<pc-button>`](../pc-button) — interactive elements
+
+Examples: [2D Screen](https://playcanvas.github.io/web-components/examples/2d-screen.html), [UI Layout](https://playcanvas.github.io/web-components/examples/ui-layout.html) and [Scroll View](https://playcanvas.github.io/web-components/examples/scroll-view.html).

--- a/docs/user-manual/web-components/tags/pc-script-instance.md
+++ b/docs/user-manual/web-components/tags/pc-script-instance.md
@@ -83,3 +83,11 @@ A `rotate` script attached to a cube. Script classes usually load from a [`<pc-a
 You can programmatically create and manipulate `<pc-script-instance>` elements using the [ScriptInstanceElement API](https://api.playcanvas.com/web-components/classes/ScriptInstanceElement.html).
 
 The element becomes ready once its script instance has been created — await `whenReady('pc-script-instance')` or the element's `ready()` promise. The live `Script` instance is then available via the `script` property, and script attributes can be read and written as an object via the `scriptAttributes` property.
+
+## See Also
+
+* [`<pc-script>`](../pc-script) — the component that hosts instances
+* [`<pc-asset>`](../pc-asset) — loads the script's module
+* [Adding Behavior with Scripts](../scripting.md) — declaring and typing script attributes
+
+Examples: [Tweening](https://playcanvas.github.io/web-components/examples/tweening.html), [Solar System](https://playcanvas.github.io/web-components/examples/solar-system.html) and [Annotations](https://playcanvas.github.io/web-components/examples/annotations.html).

--- a/docs/user-manual/web-components/tags/pc-script.md
+++ b/docs/user-manual/web-components/tags/pc-script.md
@@ -74,3 +74,5 @@ One script component holding two scripts — `rotate` spins the cube while `puls
 ## JavaScript Interface
 
 You can programmatically create and manipulate `<pc-script>` elements using the [ScriptComponentElement API](https://api.playcanvas.com/web-components/classes/ScriptComponentElement.html).
+
+The `component` property is the engine [ScriptComponent](https://api.playcanvas.com/engine/classes/ScriptComponent.html) the element adds — `null` until the element is ready — and everything the attributes do not expose is available on it.

--- a/docs/user-manual/web-components/tags/pc-script.md
+++ b/docs/user-manual/web-components/tags/pc-script.md
@@ -76,3 +76,11 @@ One script component holding two scripts — `rotate` spins the cube while `puls
 You can programmatically create and manipulate `<pc-script>` elements using the [ScriptComponentElement API](https://api.playcanvas.com/web-components/classes/ScriptComponentElement.html).
 
 The `component` property is the engine [ScriptComponent](https://api.playcanvas.com/engine/classes/ScriptComponent.html) the element adds — `null` until the element is ready — and everything the attributes do not expose is available on it.
+
+## See Also
+
+* [`<pc-script-instance>`](../pc-script-instance) — each script the component runs
+* [`<pc-asset>`](../pc-asset) — how script modules are loaded
+* [Adding Behavior with Scripts](../scripting.md) — writing scripts and declaring their attributes
+
+Examples: [Tweening](https://playcanvas.github.io/web-components/examples/tweening.html), [First Person Controller](https://playcanvas.github.io/web-components/examples/first-person-controller.html) and [Solar System](https://playcanvas.github.io/web-components/examples/solar-system.html).

--- a/docs/user-manual/web-components/tags/pc-scroll-view.md
+++ b/docs/user-manual/web-components/tags/pc-scroll-view.md
@@ -97,3 +97,11 @@ Scroll the striped content with the mouse wheel, by dragging it, or with the scr
 You can programmatically create and manipulate `<pc-scroll-view>` elements using the [ScrollViewComponentElement API](https://api.playcanvas.com/web-components/classes/ScrollViewComponentElement.html).
 
 The `component` property is the engine [ScrollViewComponent](https://api.playcanvas.com/engine/classes/ScrollViewComponent.html) the element adds — `null` until the element is ready — and everything the attributes do not expose is available on it.
+
+## See Also
+
+* [`<pc-scrollbar>`](../pc-scrollbar) — drives the view and reflects its position
+* [`<pc-element>`](../pc-element) — the viewport and content are elements; `mask` clips the content
+* [`<pc-layout-group>`](../pc-layout-group) — lays out the content's children
+
+Examples: [Scroll View](https://playcanvas.github.io/web-components/examples/scroll-view.html).

--- a/docs/user-manual/web-components/tags/pc-scroll-view.md
+++ b/docs/user-manual/web-components/tags/pc-scroll-view.md
@@ -95,3 +95,5 @@ Scroll the striped content with the mouse wheel, by dragging it, or with the scr
 ## JavaScript Interface
 
 You can programmatically create and manipulate `<pc-scroll-view>` elements using the [ScrollViewComponentElement API](https://api.playcanvas.com/web-components/classes/ScrollViewComponentElement.html).
+
+The `component` property is the engine [ScrollViewComponent](https://api.playcanvas.com/engine/classes/ScrollViewComponent.html) the element adds — `null` until the element is ready — and everything the attributes do not expose is available on it.

--- a/docs/user-manual/web-components/tags/pc-scrollbar.md
+++ b/docs/user-manual/web-components/tags/pc-scrollbar.md
@@ -60,3 +60,11 @@ A standalone vertical scrollbar — drag the orange handle. Try a different `han
 You can programmatically create and manipulate `<pc-scrollbar>` elements using the [ScrollbarComponentElement API](https://api.playcanvas.com/web-components/classes/ScrollbarComponentElement.html).
 
 The `component` property is the engine [ScrollbarComponent](https://api.playcanvas.com/engine/classes/ScrollbarComponent.html) the element adds — `null` until the element is ready — and everything the attributes do not expose is available on it.
+
+## See Also
+
+* [`<pc-scroll-view>`](../pc-scroll-view) — the view a scrollbar drives
+* [`<pc-element>`](../pc-element) — the track and handle are image elements
+* [`<pc-screen>`](../pc-screen) — the screen the scrollbar renders on
+
+Examples: [Scroll View](https://playcanvas.github.io/web-components/examples/scroll-view.html).

--- a/docs/user-manual/web-components/tags/pc-scrollbar.md
+++ b/docs/user-manual/web-components/tags/pc-scrollbar.md
@@ -58,3 +58,5 @@ A standalone vertical scrollbar — drag the orange handle. Try a different `han
 ## JavaScript Interface
 
 You can programmatically create and manipulate `<pc-scrollbar>` elements using the [ScrollbarComponentElement API](https://api.playcanvas.com/web-components/classes/ScrollbarComponentElement.html).
+
+The `component` property is the engine [ScrollbarComponent](https://api.playcanvas.com/engine/classes/ScrollbarComponent.html) the element adds — `null` until the element is ready — and everything the attributes do not expose is available on it.

--- a/docs/user-manual/web-components/tags/pc-sky.md
+++ b/docs/user-manual/web-components/tags/pc-sky.md
@@ -54,3 +54,5 @@ An equirectangular texture as a dome-projected sky that also lights the scene (n
 ## JavaScript Interface
 
 You can programmatically create and manipulate `<pc-sky>` elements using the [SkyElement API](https://api.playcanvas.com/web-components/classes/SkyElement.html).
+
+The attributes are mirrored as properties. The sky itself is engine scene state — `sky` and the environment atlas on the [Scene](https://api.playcanvas.com/engine/classes/Scene.html) — reached through the `<pc-scene>` element's `scene` property.

--- a/docs/user-manual/web-components/tags/pc-sky.md
+++ b/docs/user-manual/web-components/tags/pc-sky.md
@@ -56,3 +56,11 @@ An equirectangular texture as a dome-projected sky that also lights the scene (n
 You can programmatically create and manipulate `<pc-sky>` elements using the [SkyElement API](https://api.playcanvas.com/web-components/classes/SkyElement.html).
 
 The attributes are mirrored as properties. The sky itself is engine scene state — `sky` and the environment atlas on the [Scene](https://api.playcanvas.com/engine/classes/Scene.html) — reached through the `<pc-scene>` element's `scene` property.
+
+## See Also
+
+* [`<pc-asset>`](../pc-asset) — the equirectangular texture asset
+* [`<pc-scene>`](../pc-scene) — exposure, and where the sky lives in the engine
+* [`<pc-light>`](../pc-light) — direct lights alongside the sky's image-based lighting
+
+Examples: [GLB Loader](https://playcanvas.github.io/web-components/examples/glb-loader.html), [Product Viewer](https://playcanvas.github.io/web-components/examples/product-viewer.html) and [Shadow Cascades](https://playcanvas.github.io/web-components/examples/shadow-cascades.html).

--- a/docs/user-manual/web-components/tags/pc-sound-slot.md
+++ b/docs/user-manual/web-components/tags/pc-sound-slot.md
@@ -75,3 +75,11 @@ Two slots playing the same clip — the second at half `pitch`. Browsers only al
 You can programmatically create and manipulate `<pc-sound-slot>` elements using the [SoundSlotElement API](https://api.playcanvas.com/web-components/classes/SoundSlotElement.html).
 
 The attributes are mirrored as properties. The engine [SoundSlot](https://api.playcanvas.com/engine/classes/SoundSlot.html) itself belongs to the parent component: `soundElement.component.slot(name)` returns it.
+
+## See Also
+
+* [`<pc-sound>`](../pc-sound) — the component a slot belongs to
+* [`<pc-asset>`](../pc-asset) — the audio asset a slot plays
+* [`<pc-audio-listener>`](../pc-audio-listener) — positional playback needs a listener
+
+Examples: [Basic Sound](https://playcanvas.github.io/web-components/examples/basic-sound.html), [Positional Sound](https://playcanvas.github.io/web-components/examples/positional-sound.html) and [Falling Blocks](https://playcanvas.github.io/web-components/examples/falling-blocks.html).

--- a/docs/user-manual/web-components/tags/pc-sound-slot.md
+++ b/docs/user-manual/web-components/tags/pc-sound-slot.md
@@ -73,3 +73,5 @@ Two slots playing the same clip — the second at half `pitch`. Browsers only al
 ## JavaScript Interface
 
 You can programmatically create and manipulate `<pc-sound-slot>` elements using the [SoundSlotElement API](https://api.playcanvas.com/web-components/classes/SoundSlotElement.html).
+
+The attributes are mirrored as properties. The engine [SoundSlot](https://api.playcanvas.com/engine/classes/SoundSlot.html) itself belongs to the parent component: `soundElement.component.slot(name)` returns it.

--- a/docs/user-manual/web-components/tags/pc-sound.md
+++ b/docs/user-manual/web-components/tags/pc-sound.md
@@ -77,3 +77,5 @@ One sound component holding two slots — looping footsteps and a one-shot. The 
 ## JavaScript Interface
 
 You can programmatically create and manipulate `<pc-sound>` elements using the [SoundComponentElement API](https://api.playcanvas.com/web-components/classes/SoundComponentElement.html).
+
+The `component` property is the engine [SoundComponent](https://api.playcanvas.com/engine/classes/SoundComponent.html) the element adds — `null` until the element is ready — and everything the attributes do not expose is available on it.

--- a/docs/user-manual/web-components/tags/pc-sound.md
+++ b/docs/user-manual/web-components/tags/pc-sound.md
@@ -79,3 +79,11 @@ One sound component holding two slots — looping footsteps and a one-shot. The 
 You can programmatically create and manipulate `<pc-sound>` elements using the [SoundComponentElement API](https://api.playcanvas.com/web-components/classes/SoundComponentElement.html).
 
 The `component` property is the engine [SoundComponent](https://api.playcanvas.com/engine/classes/SoundComponent.html) the element adds — `null` until the element is ready — and everything the attributes do not expose is available on it.
+
+## See Also
+
+* [`<pc-sound-slot>`](../pc-sound-slot) — each clip the component plays
+* [`<pc-audio-listener>`](../pc-audio-listener) — required for positional sound
+* [`<pc-asset>`](../pc-asset) — audio assets
+
+Examples: [Basic Sound](https://playcanvas.github.io/web-components/examples/basic-sound.html), [Positional Sound](https://playcanvas.github.io/web-components/examples/positional-sound.html) and [Falling Blocks](https://playcanvas.github.io/web-components/examples/falling-blocks.html).

--- a/docs/user-manual/web-components/tags/pc-wasm.md
+++ b/docs/user-manual/web-components/tags/pc-wasm.md
@@ -84,3 +84,11 @@ Loading the `Ammo` physics module. The box only falls because the module is decl
 You can programmatically create and manipulate `<pc-wasm>` elements using the [WasmElement API](https://api.playcanvas.com/web-components/classes/WasmElement.html).
 
 The element exposes no engine object of its own. Once it is ready the module has been instantiated through the engine's `WasmModule` under its `name` (`Basis` goes through the engine's Basis initializer instead), and the global the module defines, such as `Ammo`, is available to scripts.
+
+## See Also
+
+* [`<pc-rigid-body>`](../pc-rigid-body) — physics, the usual reason to load Ammo
+* [`<pc-collision>`](../pc-collision) — collision shapes for physics
+* [`<pc-app>`](../pc-app) — waits for every module before it boots
+
+Examples: [Basic Physics](https://playcanvas.github.io/web-components/examples/basic-physics.html), [Vehicle Physics](https://playcanvas.github.io/web-components/examples/vehicle-physics.html) and [Video Texture](https://playcanvas.github.io/web-components/examples/video-texture.html).

--- a/docs/user-manual/web-components/tags/pc-wasm.md
+++ b/docs/user-manual/web-components/tags/pc-wasm.md
@@ -82,3 +82,5 @@ Loading the `Ammo` physics module. The box only falls because the module is decl
 ## JavaScript Interface
 
 You can programmatically create and manipulate `<pc-wasm>` elements using the [WasmElement API](https://api.playcanvas.com/web-components/classes/WasmElement.html).
+
+The element exposes no engine object of its own. Once it is ready the module has been instantiated through the engine's `WasmModule` under its `name` (`Basis` goes through the engine's Basis initializer instead), and the global the module defines, such as `Ammo`, is available to scripts.

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-anim-clip.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-anim-clip.md
@@ -147,3 +147,10 @@ document.querySelector('pc-anim').appendChild(clip);
 await clip.ready();
 document.querySelector('pc-anim').transition('wave');
 ```
+
+## 関連項目 {#see-also}
+
+* [`<pc-anim>`](../pc-anim) — クリップが属するコンポーネント
+* [`<pc-asset>`](../pc-asset) — クリップのトラックの元になるコンテナまたはアニメーションアセット
+
+サンプル: [Robot Arm](https://playcanvas.github.io/web-components/examples/robot-arm.html)

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-anim.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-anim.md
@@ -193,3 +193,11 @@ console.log(anim.clips); // ['walk', 'stalk']
 ```
 
 この要素が公開していない機能は`component`（エンジンの[AnimComponent](https://api.playcanvas.com/engine/classes/AnimComponent.html)）から利用できます。再生ヘッド（`baseLayer.activeStateCurrentTime`）、アクティブなクリップの長さ、そしてフラットなクリップ集合を超えるアニメーションのためのステートグラフやブレンドツリーなどです。
+
+## 関連項目 {#see-also}
+
+* [`<pc-anim-clip>`](../pc-anim-clip) — コンポーネントが再生する各クリップを宣言します
+* [`<pc-model>`](../pc-model) — 通常のホスト。そのGLBがアニメーショントラックを供給します
+* [`<pc-asset>`](../pc-asset) — 別のGLBやanimclip JSONからクリップを供給します
+
+サンプル: [GLB Animation](https://playcanvas.github.io/web-components/examples/glb-animation.html)、[Robot Arm](https://playcanvas.github.io/web-components/examples/robot-arm.html)

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-app.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-app.md
@@ -114,3 +114,5 @@ document.querySelector('pc-app').addEventListener('error', (event) => {
 ## JavaScriptインターフェース {#javascript-interface}
 
 [AppElement API](https://api.playcanvas.com/web-components/classes/AppElement.html)を使用して、`<pc-app>`要素をプログラムで作成および操作できます。
+
+`app`プロパティは、実行中のエンジンの[AppBase](https://api.playcanvas.com/engine/classes/AppBase.html)です。要素の準備が完了するまでは`null`で、シーン、アセットレジストリ、レンダーループにアクセスできます。`elementFromEntity()`は、エンジンのエンティティからそれを表す要素を返します。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-app.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-app.md
@@ -116,3 +116,12 @@ document.querySelector('pc-app').addEventListener('error', (event) => {
 [AppElement API](https://api.playcanvas.com/web-components/classes/AppElement.html)を使用して、`<pc-app>`要素をプログラムで作成および操作できます。
 
 `app`プロパティは、実行中のエンジンの[AppBase](https://api.playcanvas.com/engine/classes/AppBase.html)です。要素の準備が完了するまでは`null`で、シーン、アセットレジストリ、レンダーループにアクセスできます。`elementFromEntity()`は、エンジンのエンティティからそれを表す要素を返します。
+
+## 関連項目 {#see-also}
+
+* [`<pc-scene>`](../pc-scene) — アプリがレンダリングする唯一のシーン
+* [`<pc-asset>`](../pc-asset) — シーンが始まる前にアプリがプリロードするリソース
+* [`<pc-wasm>`](../pc-wasm) — 物理などアプリが起動前にロードするモジュール
+* [プログラムによるアクセス](../programmatic-access.md) — JavaScriptから`ready`を待ち、`app`にアクセスする方法
+
+サンプル: [Spinning Cube](https://playcanvas.github.io/web-components/examples/spinning-cube.html)、[Basic Shapes](https://playcanvas.github.io/web-components/examples/basic-shapes.html)

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-asset.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-asset.md
@@ -140,3 +140,5 @@ document.querySelector('pc-app').addEventListener('error', (event) => {
 ## JavaScriptインターフェース {#javascript-interface}
 
 [AssetElement API](https://api.playcanvas.com/web-components/classes/AssetElement.html)を使用して、`<pc-asset>`要素をプログラムで作成および操作できます。
+
+`asset`プロパティは、この要素が登録したエンジンの[Asset](https://api.playcanvas.com/engine/classes/Asset.html)です。要素の準備が完了するまでは`null`です。`AssetElement.get(id)`を使えば、要素を保持せずに`id`でアセットを取得できます。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-asset.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-asset.md
@@ -142,3 +142,12 @@ document.querySelector('pc-app').addEventListener('error', (event) => {
 [AssetElement API](https://api.playcanvas.com/web-components/classes/AssetElement.html)を使用して、`<pc-asset>`要素をプログラムで作成および操作できます。
 
 `asset`プロパティは、この要素が登録したエンジンの[Asset](https://api.playcanvas.com/engine/classes/Asset.html)です。要素の準備が完了するまでは`null`です。`AssetElement.get(id)`を使えば、要素を保持せずに`id`でアセットを取得できます。
+
+## 関連項目 {#see-also}
+
+* [`<pc-model>`](../pc-model) — コンテナアセットをインスタンス化します
+* [`<pc-material>`](../pc-material) — テクスチャアセットをマップとして受け取ります
+* [`<pc-sound-slot>`](../pc-sound-slot) — オーディオアセットを再生します
+* [`<pc-script-instance>`](../pc-script-instance) — アセットとして読み込んだスクリプトを実行します
+
+サンプル: [GLB Loader](https://playcanvas.github.io/web-components/examples/glb-loader.html)、[Video Texture](https://playcanvas.github.io/web-components/examples/video-texture.html)、[Basic Sound](https://playcanvas.github.io/web-components/examples/basic-sound.html)

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-audio-listener.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-audio-listener.md
@@ -79,3 +79,11 @@ description: "pc-audio-listener要素のリファレンス: 位置サウンド�
 [AudioListenerComponentElement API](https://api.playcanvas.com/web-components/classes/AudioListenerComponentElement.html)を使用して、`<pc-audio-listener>`要素をプログラムで作成および操作できます。
 
 `component`プロパティは、この要素が追加するエンジンの[AudioListenerComponent](https://api.playcanvas.com/engine/classes/AudioListenerComponent.html)です。要素の準備が完了するまでは`null`で、属性が公開していないものはすべてここから利用できます。
+
+## 関連項目 {#see-also}
+
+* [`<pc-sound>`](../pc-sound) — リスナーが聴く位置音源
+* [`<pc-sound-slot>`](../pc-sound-slot) — それらの音源が再生するクリップ
+* [`<pc-camera>`](../pc-camera) — リスナーは通常カメラのエンティティに載せます
+
+サンプル: [Positional Sound](https://playcanvas.github.io/web-components/examples/positional-sound.html)

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-audio-listener.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-audio-listener.md
@@ -77,3 +77,5 @@ description: "pc-audio-listener要素のリファレンス: 位置サウンド�
 ## JavaScriptインターフェース {#javascript-interface}
 
 [AudioListenerComponentElement API](https://api.playcanvas.com/web-components/classes/AudioListenerComponentElement.html)を使用して、`<pc-audio-listener>`要素をプログラムで作成および操作できます。
+
+`component`プロパティは、この要素が追加するエンジンの[AudioListenerComponent](https://api.playcanvas.com/engine/classes/AudioListenerComponent.html)です。要素の準備が完了するまでは`null`で、属性が公開していないものはすべてここから利用できます。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-button.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-button.md
@@ -89,3 +89,5 @@ button.component.on('click', () => {
 ## JavaScriptインターフェース {#javascript-interface}
 
 [ButtonComponentElement API](https://api.playcanvas.com/web-components/classes/ButtonComponentElement.html)を使用して、`<pc-button>`要素をプログラムで作成および操作できます。
+
+`component`プロパティは、この要素が追加するエンジンの[ButtonComponent](https://api.playcanvas.com/engine/classes/ButtonComponent.html)です。要素の準備が完了するまでは`null`で、属性が公開していないものはすべてここから利用できます。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-button.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-button.md
@@ -91,3 +91,11 @@ button.component.on('click', () => {
 [ButtonComponentElement API](https://api.playcanvas.com/web-components/classes/ButtonComponentElement.html)を使用して、`<pc-button>`要素をプログラムで作成および操作できます。
 
 `component`プロパティは、この要素が追加するエンジンの[ButtonComponent](https://api.playcanvas.com/engine/classes/ButtonComponent.html)です。要素の準備が完了するまでは`null`で、属性が公開していないものはすべてここから利用できます。
+
+## 関連項目 {#see-also}
+
+* [`<pc-element>`](../pc-element) — ボタンが入力と遷移に必要とするイメージ要素
+* [`<pc-screen>`](../pc-screen) — ボタンの要素階層が載るスクリーン
+* [`<pc-entity>`](../pc-entity) — スクリーンを使わずに3Dオブジェクトのクリックやポインターイベントを扱う
+
+サンプル: [UI Layout](https://playcanvas.github.io/web-components/examples/ui-layout.html)、[Scroll View](https://playcanvas.github.io/web-components/examples/scroll-view.html)

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-camera.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-camera.md
@@ -74,3 +74,12 @@ description: "pc-camera要素のリファレンス: エンジンのカメラComp
 [CameraComponentElement API](https://api.playcanvas.com/web-components/classes/CameraComponentElement.html)を使用して、`<pc-camera>`要素をプログラムで作成および操作できます。
 
 `component`プロパティは、この要素が追加するエンジンの[CameraComponent](https://api.playcanvas.com/engine/classes/CameraComponent.html)です。要素の準備が完了するまでは`null`で、属性が公開していないものはすべてここから利用できます。
+
+## 関連項目 {#see-also}
+
+* [`<pc-scene>`](../pc-scene) — カメラのトーンマッピングと組み合わせて働く露出とフォグ
+* [`<pc-sky>`](../pc-sky) — クリアカラーの代わりに背景となるスカイボックス
+* [`<pc-script>`](../pc-script) — カメラ操作はカメラの隣に付けるエンジンスクリプト
+* [XR のサポート](../xr.md) — カメラ要素からVRやARを開始する方法
+
+サンプル: [Basic Shapes](https://playcanvas.github.io/web-components/examples/basic-shapes.html)、[First Person Controller](https://playcanvas.github.io/web-components/examples/first-person-controller.html)

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-camera.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-camera.md
@@ -72,3 +72,5 @@ description: "pc-camera要素のリファレンス: エンジンのカメラComp
 ## JavaScriptインターフェース {#javascript-interface}
 
 [CameraComponentElement API](https://api.playcanvas.com/web-components/classes/CameraComponentElement.html)を使用して、`<pc-camera>`要素をプログラムで作成および操作できます。
+
+`component`プロパティは、この要素が追加するエンジンの[CameraComponent](https://api.playcanvas.com/engine/classes/CameraComponent.html)です。要素の準備が完了するまでは`null`で、属性が公開していないものはすべてここから利用できます。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-collision.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-collision.md
@@ -89,3 +89,11 @@ description: "pc-collision要素のリファレンス: rigid bodyと組み合わ
 [CollisionComponentElement API](https://api.playcanvas.com/web-components/classes/CollisionComponentElement.html)を使用して、`<pc-collision>`要素をプログラムで作成および操作できます。
 
 `component`プロパティは、この要素が追加するエンジンの[CollisionComponent](https://api.playcanvas.com/engine/classes/CollisionComponent.html)です。要素の準備が完了するまでは`null`で、属性が公開していないものはすべてここから利用できます。
+
+## 関連項目 {#see-also}
+
+* [`<pc-rigid-body>`](../pc-rigid-body) — 衝突形状を物理に参加させます
+* [`<pc-joint>`](../pc-joint) — 衝突形状を持つ2つのボディを拘束します
+* [`<pc-wasm>`](../pc-wasm) — 物理に必要なAmmoモジュールをロードします
+
+サンプル: [Basic Physics](https://playcanvas.github.io/web-components/examples/basic-physics.html)、[Physics Cluster](https://playcanvas.github.io/web-components/examples/physics-cluster.html)、[Ragdoll](https://playcanvas.github.io/web-components/examples/ragdoll.html)

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-collision.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-collision.md
@@ -87,3 +87,5 @@ description: "pc-collision要素のリファレンス: rigid bodyと組み合わ
 ## JavaScriptインターフェース {#javascript-interface}
 
 [CollisionComponentElement API](https://api.playcanvas.com/web-components/classes/CollisionComponentElement.html)を使用して、`<pc-collision>`要素をプログラムで作成および操作できます。
+
+`component`プロパティは、この要素が追加するエンジンの[CollisionComponent](https://api.playcanvas.com/engine/classes/CollisionComponent.html)です。要素の準備が完了するまでは`null`で、属性が公開していないものはすべてここから利用できます。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-element.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-element.md
@@ -89,3 +89,5 @@ description: "pc-element要素のリファレンス: フォント、スプライ
 ## JavaScriptインターフェース {#javascript-interface}
 
 [ElementComponentElement API](https://api.playcanvas.com/web-components/classes/ElementComponentElement.html)を使用して、`<pc-element>`要素をプログラムで作成および操作できます。
+
+`component`プロパティは、この要素が追加するエンジンの[ElementComponent](https://api.playcanvas.com/engine/classes/ElementComponent.html)です。要素の準備が完了するまでは`null`で、属性が公開していないものはすべてここから利用できます。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-element.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-element.md
@@ -91,3 +91,12 @@ description: "pc-element要素のリファレンス: フォント、スプライ
 [ElementComponentElement API](https://api.playcanvas.com/web-components/classes/ElementComponentElement.html)を使用して、`<pc-element>`要素をプログラムで作成および操作できます。
 
 `component`プロパティは、この要素が追加するエンジンの[ElementComponent](https://api.playcanvas.com/engine/classes/ElementComponent.html)です。要素の準備が完了するまでは`null`で、属性が公開していないものはすべてここから利用できます。
+
+## 関連項目 {#see-also}
+
+* [`<pc-screen>`](../pc-screen) — すべての要素はスクリーンの下に置きます
+* [`<pc-button>`](../pc-button) — イメージ要素をインタラクティブにします
+* [`<pc-layout-group>`](../pc-layout-group) — 兄弟要素を自動的に配置します
+* [`<pc-scroll-view>`](../pc-scroll-view) — ビューポートの中でコンテンツ要素をスクロールします
+
+サンプル: [2D Screen](https://playcanvas.github.io/web-components/examples/2d-screen.html)、[Text](https://playcanvas.github.io/web-components/examples/text.html)、[3D Text](https://playcanvas.github.io/web-components/examples/3d-text.html)、[UI Layout](https://playcanvas.github.io/web-components/examples/ui-layout.html)

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-entity.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-entity.md
@@ -95,4 +95,6 @@ description: "pc-entity要素のリファレンス: 名前、変換、階層の�
 
 [EntityElement API](https://api.playcanvas.com/web-components/classes/EntityElement.html)を使用して、`<pc-entity>`要素をプログラムで作成および操作できます。
 
+`entity`プロパティは、この要素が作成するエンジンの[Entity](https://api.playcanvas.com/engine/classes/Entity.html)です。要素の準備が完了するまでは`null`で、`lookAt()`から子タグが追加したコンポーネントまで、属性がカバーしないものはすべてここから利用できます。
+
 エンティティのサブツリーのコピーを大量に作るには、ネイティブの `<template>` 要素の中に一度だけ宣言してクローンしてください — [テンプレートによる再利用可能なシーン](../templates.md)を参照してください。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-entity.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-entity.md
@@ -98,3 +98,12 @@ description: "pc-entity要素のリファレンス: 名前、変換、階層の�
 `entity`プロパティは、この要素が作成するエンジンの[Entity](https://api.playcanvas.com/engine/classes/Entity.html)です。要素の準備が完了するまでは`null`で、`lookAt()`から子タグが追加したコンポーネントまで、属性がカバーしないものはすべてここから利用できます。
 
 エンティティのサブツリーのコピーを大量に作るには、ネイティブの `<template>` 要素の中に一度だけ宣言してクローンしてください — [テンプレートによる再利用可能なシーン](../templates.md)を参照してください。
+
+## 関連項目 {#see-also}
+
+* [`<pc-model>`](../pc-model) — GLBをインスタンス化するエンティティ
+* [`<pc-node>`](../pc-node) — 名前で指定する、読み込まれたモデル内のエンティティ
+* [`<pc-script>`](../pc-script) — エンティティに付ける振る舞い
+* [テンプレートによる再利用可能なシーン](../templates.md) — `<template>`からエンティティのサブツリーをクローンする方法
+
+サンプル: [Basic Shapes](https://playcanvas.github.io/web-components/examples/basic-shapes.html)、[Falling Blocks](https://playcanvas.github.io/web-components/examples/falling-blocks.html)

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-gsplat.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-gsplat.md
@@ -55,4 +55,6 @@ description: "pc-gsplat要素のリファレンス: Gaussian splat Assetをレ�
 
 [GSplatComponentElement API](https://api.playcanvas.com/web-components/classes/GSplatComponentElement.html)を使用して、`<pc-gsplat>`要素をプログラムで作成および操作できます。
 
+`component`プロパティは、この要素が追加するエンジンの[GSplatComponent](https://api.playcanvas.com/engine/classes/GSplatComponent.html)です。要素の準備が完了するまでは`null`で、属性が公開していないものはすべてここから利用できます。
+
 スプラットのワークフローはサンプルでいくつか扱っています。[Basic Splat](https://playcanvas.github.io/web-components/examples/basic-splat.html)、[Splat Annotations](https://playcanvas.github.io/web-components/examples/splat-annotations.html)、[Splat Flipbook](https://playcanvas.github.io/web-components/examples/splat-flipbook.html)、[Splat Streaming](https://playcanvas.github.io/web-components/examples/splat-streaming.html)です。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-gsplat.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-gsplat.md
@@ -57,4 +57,10 @@ description: "pc-gsplat要素のリファレンス: Gaussian splat Assetをレ�
 
 `component`プロパティは、この要素が追加するエンジンの[GSplatComponent](https://api.playcanvas.com/engine/classes/GSplatComponent.html)です。要素の準備が完了するまでは`null`で、属性が公開していないものはすべてここから利用できます。
 
-スプラットのワークフローはサンプルでいくつか扱っています。[Basic Splat](https://playcanvas.github.io/web-components/examples/basic-splat.html)、[Splat Annotations](https://playcanvas.github.io/web-components/examples/splat-annotations.html)、[Splat Flipbook](https://playcanvas.github.io/web-components/examples/splat-flipbook.html)、[Splat Streaming](https://playcanvas.github.io/web-components/examples/splat-streaming.html)です。
+## 関連項目 {#see-also}
+
+* [`<pc-asset>`](../pc-asset) — `gsplat`アセットとして宣言するスプラットファイル
+* [`<pc-app>`](../pc-app) — スプラットに推奨するデバイス設定
+* [Webコンポーネントの使用](../../gaussian-splatting/building/your-first-app/web-components.md) — はじめてのスプラットアプリを順を追って作る
+
+サンプル: [Basic Splat](https://playcanvas.github.io/web-components/examples/basic-splat.html)、[Splat Annotations](https://playcanvas.github.io/web-components/examples/splat-annotations.html)、[Splat Flipbook](https://playcanvas.github.io/web-components/examples/splat-flipbook.html)、[Splat Streaming](https://playcanvas.github.io/web-components/examples/splat-streaming.html)

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-joint.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-joint.md
@@ -186,3 +186,11 @@ joint.entityA = '#link-3'; // ここで再解決されます
 ```
 
 どちらも他のエンティティ参照属性と同じ参照形式を受け付けます。エンティティの `name`（最も近い外側のエンティティから解決されます）、またはドキュメント全体の `#` セレクターです。[エンティティ参照](../attributes.md#entity-references)を参照してください。
+
+## 関連項目 {#see-also}
+
+* [`<pc-rigid-body>`](../pc-rigid-body) — 拘束する両方のエンティティに必要です
+* [`<pc-collision>`](../pc-collision) — ボディに形状を与えます
+* [`<pc-wasm>`](../pc-wasm) — 物理に必要なAmmoモジュールをロードします
+
+サンプル: [Physics Joints](https://playcanvas.github.io/web-components/examples/physics-joints.html)、[Ragdoll](https://playcanvas.github.io/web-components/examples/ragdoll.html)、[AR Wiener Storm](https://playcanvas.github.io/web-components/examples/ar-wiener-storm.html)

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-joint.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-joint.md
@@ -176,6 +176,8 @@ joint.component.refreshFrames(); // 復帰し、現在のトランスフォー�
 
 [JointComponentElement API](https://api.playcanvas.com/web-components/classes/JointComponentElement.html)を使用して、`<pc-joint>`要素をプログラムで作成および操作できます。
 
+`component`プロパティは、この要素が追加するエンジンの[JointComponent](https://api.playcanvas.com/engine/classes/JointComponent.html)です。要素の準備が完了するまでは`null`で、属性が公開していないものはすべてここから利用できます。
+
 `entity-a`と`entity-b`は設定された時点で解決されるため、後から作成されたエンティティは自動では取り込まれません。存在する状態で属性を再設定してください。
 
 ```javascript

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-layout-child.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-layout-child.md
@@ -67,3 +67,5 @@ description: "pc-layout-child要素のリファレンス: レイアウトグル�
 ## JavaScriptインターフェース {#javascript-interface}
 
 [LayoutChildComponentElement API](https://api.playcanvas.com/web-components/classes/LayoutChildComponentElement.html)を使用して、`<pc-layout-child>`要素をプログラムで作成および操作できます。
+
+`component`プロパティは、この要素が追加するエンジンの[LayoutChildComponent](https://api.playcanvas.com/engine/classes/LayoutChildComponent.html)です。要素の準備が完了するまでは`null`で、属性が公開していないものはすべてここから利用できます。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-layout-child.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-layout-child.md
@@ -69,3 +69,10 @@ description: "pc-layout-child要素のリファレンス: レイアウトグル�
 [LayoutChildComponentElement API](https://api.playcanvas.com/web-components/classes/LayoutChildComponentElement.html)を使用して、`<pc-layout-child>`要素をプログラムで作成および操作できます。
 
 `component`プロパティは、この要素が追加するエンジンの[LayoutChildComponent](https://api.playcanvas.com/engine/classes/LayoutChildComponent.html)です。要素の準備が完了するまでは`null`で、属性が公開していないものはすべてここから利用できます。
+
+## 関連項目 {#see-also}
+
+* [`<pc-layout-group>`](../pc-layout-group) — 子が調整するレイアウトを持つグループ
+* [`<pc-element>`](../pc-element) — 子がサイズを決める要素
+
+サンプル: [UI Layout](https://playcanvas.github.io/web-components/examples/ui-layout.html)、[Scroll View](https://playcanvas.github.io/web-components/examples/scroll-view.html)

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-layout-group.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-layout-group.md
@@ -69,4 +69,10 @@ description: "pc-layout-group要素のリファレンス: 子要素を水平ま�
 
 `component`プロパティは、この要素が追加するエンジンの[LayoutGroupComponent](https://api.playcanvas.com/engine/classes/LayoutGroupComponent.html)です。要素の準備が完了するまでは`null`で、属性が公開していないものはすべてここから利用できます。
 
-[UI Layoutのサンプル](https://playcanvas.github.io/web-components/examples/ui-layout.html)では、ワールド空間のスクリーン上にレイアウトグループを入れ子にして構築しています。
+## 関連項目 {#see-also}
+
+* [`<pc-layout-child>`](../pc-layout-child) — 子ごとのサイズ規則
+* [`<pc-element>`](../pc-element) — 配置される要素
+* [`<pc-screen>`](../pc-screen) — レイアウトが載るスクリーン
+
+サンプル: [UI Layout](https://playcanvas.github.io/web-components/examples/ui-layout.html)、[Scroll View](https://playcanvas.github.io/web-components/examples/scroll-view.html)

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-layout-group.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-layout-group.md
@@ -67,4 +67,6 @@ description: "pc-layout-group要素のリファレンス: 子要素を水平ま�
 
 [LayoutGroupComponentElement API](https://api.playcanvas.com/web-components/classes/LayoutGroupComponentElement.html)を使用して、`<pc-layout-group>`要素をプログラムで作成および操作できます。
 
+`component`プロパティは、この要素が追加するエンジンの[LayoutGroupComponent](https://api.playcanvas.com/engine/classes/LayoutGroupComponent.html)です。要素の準備が完了するまでは`null`で、属性が公開していないものはすべてここから利用できます。
+
 [UI Layoutのサンプル](https://playcanvas.github.io/web-components/examples/ui-layout.html)では、ワールド空間のスクリーン上にレイアウトグループを入れ子にして構築しています。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-light.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-light.md
@@ -109,3 +109,11 @@ description: "pc-light要素のリファレンス: ライトの種類、色、�
 [LightComponentElement API](https://api.playcanvas.com/web-components/classes/LightComponentElement.html)を使用して、`<pc-light>`要素をプログラムで作成および操作できます。
 
 `component`プロパティは、この要素が追加するエンジンの[LightComponent](https://api.playcanvas.com/engine/classes/LightComponent.html)です。要素の準備が完了するまでは`null`で、属性が公開していないものはすべてここから利用できます。
+
+## 関連項目 {#see-also}
+
+* [`<pc-scene>`](../pc-scene) — すべてのライトの寄与をスケールする露出
+* [`<pc-sky>`](../pc-sky) — 直接光が届かない部分を埋める画像ベースのライティング
+* [`<pc-render>`](../pc-render) — ライトが当たるものの`cast-shadows`と`receive-shadows`
+
+サンプル: [Basic Shapes](https://playcanvas.github.io/web-components/examples/basic-shapes.html)、[Shadow Cascades](https://playcanvas.github.io/web-components/examples/shadow-cascades.html)

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-light.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-light.md
@@ -107,3 +107,5 @@ description: "pc-light要素のリファレンス: ライトの種類、色、�
 ## JavaScriptインターフェース {#javascript-interface}
 
 [LightComponentElement API](https://api.playcanvas.com/web-components/classes/LightComponentElement.html)を使用して、`<pc-light>`要素をプログラムで作成および操作できます。
+
+`component`プロパティは、この要素が追加するエンジンの[LightComponent](https://api.playcanvas.com/engine/classes/LightComponent.html)です。要素の準備が完了するまでは`null`で、属性が公開していないものはすべてここから利用できます。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-material.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-material.md
@@ -139,3 +139,5 @@ description: "pc-material要素のリファレンス: カラー、メタルネ�
 ## JavaScriptインターフェース {#javascript-interface}
 
 [MaterialElement API](https://api.playcanvas.com/web-components/classes/MaterialElement.html)を使用して、`<pc-material>`要素をプログラムで作成および操作できます。
+
+`material`プロパティは、この要素が構築するエンジンの[StandardMaterial](https://api.playcanvas.com/engine/classes/StandardMaterial.html)です。`MaterialElement.get(id)`を使えば`id`でマテリアルを取得できます。この要素は同期的に初期化されるため、どちらも準備完了を待つ必要はありません。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-material.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-material.md
@@ -141,3 +141,11 @@ description: "pc-material要素のリファレンス: カラー、メタルネ�
 [MaterialElement API](https://api.playcanvas.com/web-components/classes/MaterialElement.html)を使用して、`<pc-material>`要素をプログラムで作成および操作できます。
 
 `material`プロパティは、この要素が構築するエンジンの[StandardMaterial](https://api.playcanvas.com/engine/classes/StandardMaterial.html)です。`MaterialElement.get(id)`を使えば`id`でマテリアルを取得できます。この要素は同期的に初期化されるため、どちらも準備完了を待つ必要はありません。
+
+## 関連項目 {#see-also}
+
+* [`<pc-render>`](../pc-render) — プリミティブにマテリアルを適用します
+* [`<pc-node>`](../pc-node) — 読み込まれたモデル内のマテリアルをオーバーライドします
+* [`<pc-asset>`](../pc-asset) — マテリアルのマップが参照するテクスチャアセット
+
+サンプル: [Basic Shapes](https://playcanvas.github.io/web-components/examples/basic-shapes.html)、[Falling Blocks](https://playcanvas.github.io/web-components/examples/falling-blocks.html)、[Car Configurator](https://playcanvas.github.io/web-components/examples/car-configurator.html)

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-model.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-model.md
@@ -198,3 +198,12 @@ Car
 マテリアルの`name`値はそのまま読み取られる実行時のラベルであり、便利な手掛かりではあるものの一意ではありません。名前のないglTFマテリアルは`Untitled`と呼ばれ、マテリアルなしでオーサリングされたプリミティブはエンジンが共有する`defaultGlbMaterial`を持ち、重複はそのまま重複し、スクリプトが割り当てを解除した場合は名前は`null`になります。一意なのは`index`です。どちらも[`<pc-node>`の`material-overrides`](../pc-node#overriding-materials)が選択に用いるもので、差し替えた[`<pc-material>`](../pc-material)は`name`属性の内容をそのまま報告します。ここで識別したいマテリアルには設定しておく価値があります。
 
 このツリーはスナップショットであり、呼び出しごとに新しく計算されます。その後の階層の変更を追跡することはなく、変更を加えても何も起こりません。プレーンなデータであるため`JSON.stringify`を通過でき、ログ出力・差分比較・テストでの検証が容易です。
+
+## 関連項目 {#see-also}
+
+* [`<pc-asset>`](../pc-asset) — モデルがインスタンス化するコンテナアセット
+* [`<pc-node>`](../pc-node) — インスタンス化された階層の内側に手を伸ばします
+* [`<pc-anim>`](../pc-anim) — GLBが持つアニメーションを再生します
+* [モデルの読み込み](../loading-models.md) — モデルを読み込み、マークアップから調整する方法
+
+サンプル: [GLB Loader](https://playcanvas.github.io/web-components/examples/glb-loader.html)、[GLB Animation](https://playcanvas.github.io/web-components/examples/glb-animation.html)、[Product Viewer](https://playcanvas.github.io/web-components/examples/product-viewer.html)

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-node.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-node.md
@@ -152,3 +152,12 @@ body.materialOverrides = null; // オーサリングされたマテリアルに�
 ```
 
 要素は代入された内容を凍結してコピーして保持するため、後からご自身のオブジェクトを変更しても何も起こりません。変更するには新しいマッピングを代入してください。プロパティへの書き込みは`material-overrides`属性に反映されません。これは他のオーバーライドプロパティの動作に従っています。
+
+## 関連項目 {#see-also}
+
+* [`<pc-model>`](../pc-model) — バインドされるノードを持つモデル
+* [`<pc-material>`](../pc-material) — `material-overrides`でノードが差し替えられるマテリアル
+* [`<pc-entity>`](../pc-entity) — ノードの下に新しいコンテンツを取り付けます
+* [モデルの読み込み](../loading-models.md) — 読み込まれたモデル内のノードを見つける方法
+
+サンプル: [Product Viewer](https://playcanvas.github.io/web-components/examples/product-viewer.html)、[Ragdoll](https://playcanvas.github.io/web-components/examples/ragdoll.html)、[Vehicle Physics](https://playcanvas.github.io/web-components/examples/vehicle-physics.html)

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-particle-system.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-particle-system.md
@@ -86,3 +86,10 @@ description: "pc-particle-system要素のリファレンス: エミッター、�
 [ParticleSystemComponentElement API](https://api.playcanvas.com/web-components/classes/ParticleSystemComponentElement.html)を使用して、`<pc-particle-system>`要素をプログラムで作成および操作できます。
 
 `component`プロパティは、この要素が追加するエンジンの[ParticleSystemComponent](https://api.playcanvas.com/engine/classes/ParticleSystemComponent.html)です。要素の準備が完了するまでは`null`で、属性が公開していないものはすべてここから利用できます。
+
+## 関連項目 {#see-also}
+
+* [`<pc-asset>`](../pc-asset) — JSON設定と、それが参照するテクスチャ
+* [`<pc-entity>`](../pc-entity) — エミッターの位置と向きを決めます
+
+サンプル: [Basic Particles](https://playcanvas.github.io/web-components/examples/basic-particles.html)

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-particle-system.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-particle-system.md
@@ -84,3 +84,5 @@ description: "pc-particle-system要素のリファレンス: エミッター、�
 ## JavaScriptインターフェース {#javascript-interface}
 
 [ParticleSystemComponentElement API](https://api.playcanvas.com/web-components/classes/ParticleSystemComponentElement.html)を使用して、`<pc-particle-system>`要素をプログラムで作成および操作できます。
+
+`component`プロパティは、この要素が追加するエンジンの[ParticleSystemComponent](https://api.playcanvas.com/engine/classes/ParticleSystemComponent.html)です。要素の準備が完了するまでは`null`で、属性が公開していないものはすべてここから利用できます。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-render.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-render.md
@@ -71,3 +71,12 @@ glTF/GLBファイルから3Dモデルをレンダリングするには、代わ�
 [RenderComponentElement API](https://api.playcanvas.com/web-components/classes/RenderComponentElement.html)を使用して、`<pc-render>`要素をプログラムで作成および操作できます。
 
 `component`プロパティは、この要素が追加するエンジンの[RenderComponent](https://api.playcanvas.com/engine/classes/RenderComponent.html)です。要素の準備が完了するまでは`null`で、属性が公開していないものはすべてここから利用できます。
+
+## 関連項目 {#see-also}
+
+* [`<pc-material>`](../pc-material) — プリミティブを描くマテリアル
+* [`<pc-model>`](../pc-model) — プリミティブの代わりにGLBをレンダリングします
+* [`<pc-light>`](../pc-light) — プリミティブに光と影を当てます
+* [`<pc-collision>`](../pc-collision) — 対応する物理形状
+
+サンプル: [Basic Shapes](https://playcanvas.github.io/web-components/examples/basic-shapes.html)、[Falling Blocks](https://playcanvas.github.io/web-components/examples/falling-blocks.html)、[Physics Joints](https://playcanvas.github.io/web-components/examples/physics-joints.html)

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-render.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-render.md
@@ -69,3 +69,5 @@ glTF/GLBファイルから3Dモデルをレンダリングするには、代わ�
 ## JavaScriptインターフェース {#javascript-interface}
 
 [RenderComponentElement API](https://api.playcanvas.com/web-components/classes/RenderComponentElement.html)を使用して、`<pc-render>`要素をプログラムで作成および操作できます。
+
+`component`プロパティは、この要素が追加するエンジンの[RenderComponent](https://api.playcanvas.com/engine/classes/RenderComponent.html)です。要素の準備が完了するまでは`null`で、属性が公開していないものはすべてここから利用できます。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-rigid-body.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-rigid-body.md
@@ -76,4 +76,11 @@ description: "pc-rigid-body要素のリファレンス: rigid bodyの種類、�
 
 `component`プロパティは、この要素が追加するエンジンの[RigidBodyComponent](https://api.playcanvas.com/engine/classes/RigidBodyComponent.html)です。要素の準備が完了するまでは`null`で、属性が公開していないものはすべてここから利用できます。
 
-物理のサンプルはこのタグを土台にしています。[Basic Physics](https://playcanvas.github.io/web-components/examples/basic-physics.html)、[Physics Cluster](https://playcanvas.github.io/web-components/examples/physics-cluster.html)、[Physics Joints](https://playcanvas.github.io/web-components/examples/physics-joints.html)、[Ragdoll](https://playcanvas.github.io/web-components/examples/ragdoll.html)、[Vehicle Physics](https://playcanvas.github.io/web-components/examples/vehicle-physics.html)です。
+## 関連項目 {#see-also}
+
+* [`<pc-collision>`](../pc-collision) — ボディが衝突する形状。すべてのリジッドボディに必要です
+* [`<pc-joint>`](../pc-joint) — 2つのボディを互いに拘束します
+* [`<pc-wasm>`](../pc-wasm) — 物理に必要なAmmoモジュールをロードします
+* [`<pc-scene>`](../pc-scene) — 重力
+
+サンプル: [Basic Physics](https://playcanvas.github.io/web-components/examples/basic-physics.html)、[Physics Cluster](https://playcanvas.github.io/web-components/examples/physics-cluster.html)、[Ragdoll](https://playcanvas.github.io/web-components/examples/ragdoll.html)、[Vehicle Physics](https://playcanvas.github.io/web-components/examples/vehicle-physics.html)

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-rigid-body.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-rigid-body.md
@@ -74,4 +74,6 @@ description: "pc-rigid-body要素のリファレンス: rigid bodyの種類、�
 
 [RigidBodyComponentElement API](https://api.playcanvas.com/web-components/classes/RigidBodyComponentElement.html)を使用して、`<pc-rigid-body>`要素をプログラムで作成および操作できます。
 
+`component`プロパティは、この要素が追加するエンジンの[RigidBodyComponent](https://api.playcanvas.com/engine/classes/RigidBodyComponent.html)です。要素の準備が完了するまでは`null`で、属性が公開していないものはすべてここから利用できます。
+
 物理のサンプルはこのタグを土台にしています。[Basic Physics](https://playcanvas.github.io/web-components/examples/basic-physics.html)、[Physics Cluster](https://playcanvas.github.io/web-components/examples/physics-cluster.html)、[Physics Joints](https://playcanvas.github.io/web-components/examples/physics-joints.html)、[Ragdoll](https://playcanvas.github.io/web-components/examples/ragdoll.html)、[Vehicle Physics](https://playcanvas.github.io/web-components/examples/vehicle-physics.html)です。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-scene.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-scene.md
@@ -62,3 +62,5 @@ description: "pc-scene要素のリファレンス: pc-app内のシーンコン�
 ## JavaScriptインターフェース {#javascript-interface}
 
 [SceneElement API](https://api.playcanvas.com/web-components/classes/SceneElement.html)を使用して、`<pc-scene>`要素をプログラムで作成および操作できます。
+
+`scene`プロパティは、エンジンの[Scene](https://api.playcanvas.com/engine/classes/Scene.html)です。要素の準備が完了するまでは`null`で、フォグ、露出、スカイはここで設定されます。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-scene.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-scene.md
@@ -64,3 +64,12 @@ description: "pc-scene要素のリファレンス: pc-app内のシーンコン�
 [SceneElement API](https://api.playcanvas.com/web-components/classes/SceneElement.html)を使用して、`<pc-scene>`要素をプログラムで作成および操作できます。
 
 `scene`プロパティは、エンジンの[Scene](https://api.playcanvas.com/engine/classes/Scene.html)です。要素の準備が完了するまでは`null`で、フォグ、露出、スカイはここで設定されます。
+
+## 関連項目 {#see-also}
+
+* [`<pc-app>`](../pc-app) — シーンを保持するアプリケーション
+* [`<pc-sky>`](../pc-sky) — シーンのスカイボックスと画像ベースのライティング
+* [`<pc-camera>`](../pc-camera) — シーンの露出のあとに適用されるトーンマッピング
+* [`<pc-rigid-body>`](../pc-rigid-body) — 重力が働くボディ
+
+サンプル: [Basic Shapes](https://playcanvas.github.io/web-components/examples/basic-shapes.html)、[Spinning Cube](https://playcanvas.github.io/web-components/examples/spinning-cube.html)

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-screen.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-screen.md
@@ -63,3 +63,12 @@ description: "pc-screen要素のリファレンス: UI要素向けの2Dスクリ
 [ScreenComponentElement API](https://api.playcanvas.com/web-components/classes/ScreenComponentElement.html)を使用して、`<pc-screen>`要素をプログラムで作成および操作できます。
 
 `component`プロパティは、この要素が追加するエンジンの[ScreenComponent](https://api.playcanvas.com/engine/classes/ScreenComponent.html)です。要素の準備が完了するまでは`null`で、属性が公開していないものはすべてここから利用できます。
+
+## 関連項目 {#see-also}
+
+* [`<pc-element>`](../pc-element) — スクリーンがレンダリングする要素
+* [`<pc-layout-group>`](../pc-layout-group) — 要素の自動配置
+* [`<pc-scroll-view>`](../pc-scroll-view) — スクリーン上でコンテンツをスクロールする
+* [`<pc-button>`](../pc-button) — インタラクティブな要素
+
+サンプル: [2D Screen](https://playcanvas.github.io/web-components/examples/2d-screen.html)、[UI Layout](https://playcanvas.github.io/web-components/examples/ui-layout.html)、[Scroll View](https://playcanvas.github.io/web-components/examples/scroll-view.html)

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-screen.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-screen.md
@@ -61,3 +61,5 @@ description: "pc-screen要素のリファレンス: UI要素向けの2Dスクリ
 ## JavaScriptインターフェース {#javascript-interface}
 
 [ScreenComponentElement API](https://api.playcanvas.com/web-components/classes/ScreenComponentElement.html)を使用して、`<pc-screen>`要素をプログラムで作成および操作できます。
+
+`component`プロパティは、この要素が追加するエンジンの[ScreenComponent](https://api.playcanvas.com/engine/classes/ScreenComponent.html)です。要素の準備が完了するまでは`null`で、属性が公開していないものはすべてここから利用できます。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-script-instance.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-script-instance.md
@@ -83,3 +83,11 @@ description: "pc-script-instance要素のリファレンス: 単一のスクリ�
 [ScriptInstanceElement API](https://api.playcanvas.com/web-components/classes/ScriptInstanceElement.html)を使用して、`<pc-script-instance>`要素をプログラムで作成および操作できます。
 
 この要素は、そのスクリプトインスタンスが作成されると準備完了になります — `whenReady('pc-script-instance')` または要素の `ready()` プロミスを待ってください。その後、ライブの `Script` インスタンスは `script` プロパティから利用でき、スクリプト属性は `scriptAttributes` プロパティを介してオブジェクトとして読み書きできます。
+
+## 関連項目 {#see-also}
+
+* [`<pc-script>`](../pc-script) — インスタンスをホストするコンポーネント
+* [`<pc-asset>`](../pc-asset) — スクリプトのモジュールをロードします
+* [スクリプトで動作を追加する](../scripting.md) — スクリプト属性の宣言と型付け
+
+サンプル: [Tweening](https://playcanvas.github.io/web-components/examples/tweening.html)、[Solar System](https://playcanvas.github.io/web-components/examples/solar-system.html)、[Annotations](https://playcanvas.github.io/web-components/examples/annotations.html)

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-script.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-script.md
@@ -74,3 +74,5 @@ description: "pc-script要素のリファレンス: pc-script-instance子要素�
 ## JavaScriptインターフェース {#javascript-interface}
 
 [ScriptComponentElement API](https://api.playcanvas.com/web-components/classes/ScriptComponentElement.html)を使用して、`<pc-script>`要素をプログラムで作成および操作できます。
+
+`component`プロパティは、この要素が追加するエンジンの[ScriptComponent](https://api.playcanvas.com/engine/classes/ScriptComponent.html)です。要素の準備が完了するまでは`null`で、属性が公開していないものはすべてここから利用できます。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-script.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-script.md
@@ -76,3 +76,11 @@ description: "pc-script要素のリファレンス: pc-script-instance子要素�
 [ScriptComponentElement API](https://api.playcanvas.com/web-components/classes/ScriptComponentElement.html)を使用して、`<pc-script>`要素をプログラムで作成および操作できます。
 
 `component`プロパティは、この要素が追加するエンジンの[ScriptComponent](https://api.playcanvas.com/engine/classes/ScriptComponent.html)です。要素の準備が完了するまでは`null`で、属性が公開していないものはすべてここから利用できます。
+
+## 関連項目 {#see-also}
+
+* [`<pc-script-instance>`](../pc-script-instance) — コンポーネントが実行する各スクリプト
+* [`<pc-asset>`](../pc-asset) — スクリプトモジュールの読み込み方法
+* [スクリプトで動作を追加する](../scripting.md) — スクリプトの書き方と属性の宣言
+
+サンプル: [Tweening](https://playcanvas.github.io/web-components/examples/tweening.html)、[First Person Controller](https://playcanvas.github.io/web-components/examples/first-person-controller.html)、[Solar System](https://playcanvas.github.io/web-components/examples/solar-system.html)

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-scroll-view.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-scroll-view.md
@@ -97,3 +97,11 @@ description: "pc-scroll-view要素のリファレンス: コンテンツ、ス�
 [ScrollViewComponentElement API](https://api.playcanvas.com/web-components/classes/ScrollViewComponentElement.html)を使用して、`<pc-scroll-view>`要素をプログラムで作成および操作できます。
 
 `component`プロパティは、この要素が追加するエンジンの[ScrollViewComponent](https://api.playcanvas.com/engine/classes/ScrollViewComponent.html)です。要素の準備が完了するまでは`null`で、属性が公開していないものはすべてここから利用できます。
+
+## 関連項目 {#see-also}
+
+* [`<pc-scrollbar>`](../pc-scrollbar) — ビューを操作し、その位置を反映します
+* [`<pc-element>`](../pc-element) — ビューポートとコンテンツは要素です。`mask`がコンテンツをクリップします
+* [`<pc-layout-group>`](../pc-layout-group) — コンテンツの子を配置します
+
+サンプル: [Scroll View](https://playcanvas.github.io/web-components/examples/scroll-view.html)

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-scroll-view.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-scroll-view.md
@@ -95,3 +95,5 @@ description: "pc-scroll-view要素のリファレンス: コンテンツ、ス�
 ## JavaScriptインターフェース {#javascript-interface}
 
 [ScrollViewComponentElement API](https://api.playcanvas.com/web-components/classes/ScrollViewComponentElement.html)を使用して、`<pc-scroll-view>`要素をプログラムで作成および操作できます。
+
+`component`プロパティは、この要素が追加するエンジンの[ScrollViewComponent](https://api.playcanvas.com/engine/classes/ScrollViewComponent.html)です。要素の準備が完了するまでは`null`で、属性が公開していないものはすべてここから利用できます。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-scrollbar.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-scrollbar.md
@@ -60,3 +60,11 @@ description: "pc-scrollbar要素のリファレンス: 向き、ハンドルサ�
 [ScrollbarComponentElement API](https://api.playcanvas.com/web-components/classes/ScrollbarComponentElement.html)を使用して、`<pc-scrollbar>`要素をプログラムで作成および操作できます。
 
 `component`プロパティは、この要素が追加するエンジンの[ScrollbarComponent](https://api.playcanvas.com/engine/classes/ScrollbarComponent.html)です。要素の準備が完了するまでは`null`で、属性が公開していないものはすべてここから利用できます。
+
+## 関連項目 {#see-also}
+
+* [`<pc-scroll-view>`](../pc-scroll-view) — スクロールバーが操作するビュー
+* [`<pc-element>`](../pc-element) — トラックとハンドルはイメージ要素です
+* [`<pc-screen>`](../pc-screen) — スクロールバーがレンダリングされるスクリーン
+
+サンプル: [Scroll View](https://playcanvas.github.io/web-components/examples/scroll-view.html)

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-scrollbar.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-scrollbar.md
@@ -58,3 +58,5 @@ description: "pc-scrollbar要素のリファレンス: 向き、ハンドルサ�
 ## JavaScriptインターフェース {#javascript-interface}
 
 [ScrollbarComponentElement API](https://api.playcanvas.com/web-components/classes/ScrollbarComponentElement.html)を使用して、`<pc-scrollbar>`要素をプログラムで作成および操作できます。
+
+`component`プロパティは、この要素が追加するエンジンの[ScrollbarComponent](https://api.playcanvas.com/engine/classes/ScrollbarComponent.html)です。要素の準備が完了するまでは`null`で、属性が公開していないものはすべてここから利用できます。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-sky.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-sky.md
@@ -56,3 +56,11 @@ description: "pc-sky要素のリファレンス: テクスチャアセットに�
 [SkyElement API](https://api.playcanvas.com/web-components/classes/SkyElement.html)を使用して、`<pc-sky>`要素をプログラムで作成および操作できます。
 
 属性はプロパティとしても利用できます。スカイそのものはエンジンのシーンの状態、つまり[Scene](https://api.playcanvas.com/engine/classes/Scene.html)の`sky`と環境アトラスであり、`<pc-scene>`要素の`scene`プロパティを通じてアクセスします。
+
+## 関連項目 {#see-also}
+
+* [`<pc-asset>`](../pc-asset) — 正距円筒テクスチャアセット
+* [`<pc-scene>`](../pc-scene) — 露出と、エンジン上でスカイが置かれる場所
+* [`<pc-light>`](../pc-light) — スカイの画像ベースライティングと組み合わせる直接光
+
+サンプル: [GLB Loader](https://playcanvas.github.io/web-components/examples/glb-loader.html)、[Product Viewer](https://playcanvas.github.io/web-components/examples/product-viewer.html)、[Shadow Cascades](https://playcanvas.github.io/web-components/examples/shadow-cascades.html)

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-sky.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-sky.md
@@ -54,3 +54,5 @@ description: "pc-sky要素のリファレンス: テクスチャアセットに�
 ## JavaScriptインターフェース {#javascript-interface}
 
 [SkyElement API](https://api.playcanvas.com/web-components/classes/SkyElement.html)を使用して、`<pc-sky>`要素をプログラムで作成および操作できます。
+
+属性はプロパティとしても利用できます。スカイそのものはエンジンのシーンの状態、つまり[Scene](https://api.playcanvas.com/engine/classes/Scene.html)の`sky`と環境アトラスであり、`<pc-scene>`要素の`scene`プロパティを通じてアクセスします。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-sound-slot.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-sound-slot.md
@@ -73,3 +73,5 @@ description: "pc-sound-slot要素のリファレンス: 位置オーディオま
 ## JavaScriptインターフェース {#javascript-interface}
 
 [SoundSlotElement API](https://api.playcanvas.com/web-components/classes/SoundSlotElement.html)を使用して、`<pc-sound-slot>`要素をプログラムで作成および操作できます。
+
+属性はプロパティとしても利用できます。エンジンの[SoundSlot](https://api.playcanvas.com/engine/classes/SoundSlot.html)そのものは親コンポーネントに属しており、`soundElement.component.slot(name)`で取得できます。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-sound-slot.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-sound-slot.md
@@ -75,3 +75,11 @@ description: "pc-sound-slot要素のリファレンス: 位置オーディオま
 [SoundSlotElement API](https://api.playcanvas.com/web-components/classes/SoundSlotElement.html)を使用して、`<pc-sound-slot>`要素をプログラムで作成および操作できます。
 
 属性はプロパティとしても利用できます。エンジンの[SoundSlot](https://api.playcanvas.com/engine/classes/SoundSlot.html)そのものは親コンポーネントに属しており、`soundElement.component.slot(name)`で取得できます。
+
+## 関連項目 {#see-also}
+
+* [`<pc-sound>`](../pc-sound) — スロットが属するコンポーネント
+* [`<pc-asset>`](../pc-asset) — スロットが再生するオーディオアセット
+* [`<pc-audio-listener>`](../pc-audio-listener) — 位置再生にはリスナーが必要です
+
+サンプル: [Basic Sound](https://playcanvas.github.io/web-components/examples/basic-sound.html)、[Positional Sound](https://playcanvas.github.io/web-components/examples/positional-sound.html)、[Falling Blocks](https://playcanvas.github.io/web-components/examples/falling-blocks.html)

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-sound.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-sound.md
@@ -79,3 +79,11 @@ description: "pc-sound要素のリファレンス: pc-sound-slotスロットと�
 [SoundComponentElement API](https://api.playcanvas.com/web-components/classes/SoundComponentElement.html)を使用して、`<pc-sound>`要素をプログラムで作成および操作できます。
 
 `component`プロパティは、この要素が追加するエンジンの[SoundComponent](https://api.playcanvas.com/engine/classes/SoundComponent.html)です。要素の準備が完了するまでは`null`で、属性が公開していないものはすべてここから利用できます。
+
+## 関連項目 {#see-also}
+
+* [`<pc-sound-slot>`](../pc-sound-slot) — コンポーネントが再生する各クリップ
+* [`<pc-audio-listener>`](../pc-audio-listener) — 位置音源に必要です
+* [`<pc-asset>`](../pc-asset) — オーディオアセット
+
+サンプル: [Basic Sound](https://playcanvas.github.io/web-components/examples/basic-sound.html)、[Positional Sound](https://playcanvas.github.io/web-components/examples/positional-sound.html)、[Falling Blocks](https://playcanvas.github.io/web-components/examples/falling-blocks.html)

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-sound.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-sound.md
@@ -77,3 +77,5 @@ description: "pc-sound要素のリファレンス: pc-sound-slotスロットと�
 ## JavaScriptインターフェース {#javascript-interface}
 
 [SoundComponentElement API](https://api.playcanvas.com/web-components/classes/SoundComponentElement.html)を使用して、`<pc-sound>`要素をプログラムで作成および操作できます。
+
+`component`プロパティは、この要素が追加するエンジンの[SoundComponent](https://api.playcanvas.com/engine/classes/SoundComponent.html)です。要素の準備が完了するまでは`null`で、属性が公開していないものはすべてここから利用できます。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-wasm.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-wasm.md
@@ -74,3 +74,11 @@ description: "pc-wasm要素のリファレンス: glue・wasm・fallbackのパ�
 [WasmElement API](https://api.playcanvas.com/web-components/classes/WasmElement.html)を使用して、`<pc-wasm>`要素をプログラムで作成および操作できます。
 
 この要素はエンジンオブジェクトを公開しません。準備が完了した時点で、モジュールは`name`の下でエンジンの`WasmModule`を通じてインスタンス化されており（`Basis`だけはエンジンのBasis初期化処理を通ります）、モジュールが定義する`Ammo`などのグローバルをスクリプトから利用できます。
+
+## 関連項目 {#see-also}
+
+* [`<pc-rigid-body>`](../pc-rigid-body) — Ammoをロードする最も一般的な理由である物理
+* [`<pc-collision>`](../pc-collision) — 物理用の衝突形状
+* [`<pc-app>`](../pc-app) — すべてのモジュールを待ってから起動します
+
+サンプル: [Basic Physics](https://playcanvas.github.io/web-components/examples/basic-physics.html)、[Vehicle Physics](https://playcanvas.github.io/web-components/examples/vehicle-physics.html)、[Video Texture](https://playcanvas.github.io/web-components/examples/video-texture.html)

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-wasm.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/web-components/tags/pc-wasm.md
@@ -72,3 +72,5 @@ description: "pc-wasm要素のリファレンス: glue・wasm・fallbackのパ�
 ## JavaScriptインターフェース {#javascript-interface}
 
 [WasmElement API](https://api.playcanvas.com/web-components/classes/WasmElement.html)を使用して、`<pc-wasm>`要素をプログラムで作成および操作できます。
+
+この要素はエンジンオブジェクトを公開しません。準備が完了した時点で、モジュールは`name`の下でエンジンの`WasmModule`を通じてインスタンス化されており（`Basis`だけはエンジンのBasis初期化処理を通ります）、モジュールが定義する`Ammo`などのグローバルをスクリプトから利用できます。

--- a/utils/check-web-components-manifest.mjs
+++ b/utils/check-web-components-manifest.mjs
@@ -88,6 +88,13 @@ const EVENTS_BY_REFERENCE = {
     'pc-model': /^(click|pointer(down|up|move|enter|leave))$/
 };
 
+// The shape every page's tail takes: a JavaScript Interface section, then See Also as the last
+// section, linking sibling tag pages and examples from the library's gallery. The Japanese pages
+// carry the English heading ids explicitly.
+const JS_INTERFACE_HEADING = { en: /^## JavaScript Interface\s*$/m, ja: /^## .*\{#javascript-interface\}\s*$/m };
+const SEE_ALSO_HEADING = { en: /^See Also\s*$/m, ja: /^.*\{#see-also\}\s*$/m };
+const EXAMPLES_URL = 'https://playcanvas.github.io/web-components/examples/';
+
 const args = process.argv.slice(2);
 const option = (flag) => {
     const index = args.indexOf(flag);
@@ -371,6 +378,31 @@ for (const locale of LOCALES) {
         for (const name of READ_ONCE[tag] ?? []) {
             if (!rows.has(name)) {
                 report(locale.name, tag, `READ_ONCE lists \`${name}\`, which is not in the attribute table`);
+            }
+        }
+
+        // Every page ends the same way: a JavaScript Interface section, then a See Also section
+        // that links at least one sibling tag page (which must exist) and at least one example
+        // from the library's gallery.
+        if (!JS_INTERFACE_HEADING[locale.name].test(markdown)) {
+            report(locale.name, tag, 'no JavaScript Interface section');
+        }
+        const sections = markdown.split(/^## /m);
+        const seeAlso = sections[sections.length - 1];
+        if (!SEE_ALSO_HEADING[locale.name].test(seeAlso)) {
+            report(locale.name, tag, 'the last section is not See Also');
+        } else {
+            const siblings = [...seeAlso.matchAll(/\]\(\.\.\/(pc-[a-z-]+)\)/g)].map((match) => match[1]);
+            if (siblings.length === 0) {
+                report(locale.name, tag, 'See Also links no sibling tag page');
+            }
+            for (const sibling of siblings) {
+                if (!elements.has(sibling)) {
+                    report(locale.name, tag, `See Also links \`<${sibling}>\`, which is not a tag`);
+                }
+            }
+            if (!seeAlso.includes(EXAMPLES_URL)) {
+                report(locale.name, tag, 'See Also links no example from the gallery');
             }
         }
 


### PR DESCRIPTION
No linked issue. Fourth step of the tag reference improvements, after #1172 (fixes), #1173 (the manifest check) and #1174 (the index and the reference types).

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/developer-site/blob/main/.github/CONTRIBUTING.md).

## What changed

Every tag page now ends the same way, in two commits that can be reviewed separately.

**1. The JavaScript Interface section names the engine object.** On 26 pages the section was a single link to the element class. Each now also says which engine object the element exposes and how to reach it:

- component tags name their `component` property and link the engine component class (`CameraComponent`, `RigidBodyComponent`, …);
- `<pc-entity>` names `entity`; `<pc-app>`, `<pc-asset>`, `<pc-material>` and `<pc-scene>` name `app`, `asset`, `material` and `scene`, with the static `get()` lookups where they exist;
- `<pc-sky>`, `<pc-sound-slot>` and `<pc-wasm>` expose no object of their own, so they say where their engine state lives instead (the scene's sky, the parent component's `slot()`, the engine's `WasmModule`);
- every sentence notes that the property is `null` until the element is ready, except `<pc-material>`, which is synchronous.

The five pages that already documented their engine objects in depth (`<pc-anim>`, `<pc-anim-clip>`, `<pc-model>`, `<pc-node>`, `<pc-script-instance>`) are unchanged. Property names and engine types were taken from the library's manifest, and the two least common engine class pages linked (`JointComponent`, `SoundSlot`) were checked to exist.

**2. A See Also section closes every page.** Two to four sibling tags, each with a one-line reason to follow the link, an occasional guide (Loading Models, Adding Behavior with Scripts, Programmatic Access, XR Support, Templates, the first splat app), and a line of official examples that use the tag. Fourteen pages previously linked no sibling at all, and only six pointed at examples.

The example picks come from a matrix of which of the library's 42 examples use each tag. Tags used everywhere (`<pc-app>`, `<pc-entity>`, `<pc-script>`, …) get two or three representative examples rather than the full list; tags with one example get that one. The three paragraphs that used to point at examples from inside the JavaScript Interface section (`<pc-gsplat>`, `<pc-layout-group>`, `<pc-rigid-body>`) moved into See Also; the contextual mentions inside explanatory prose (`<pc-light>` cascades, `<pc-anim>` robot arm, `<pc-joint>`, `<pc-model>` templates) stay where they are.

**The manifest check enforces the shape.** `utils/check-web-components-manifest.mjs` now requires a JavaScript Interface section, requires See Also to be the last section, requires it to link at least one sibling tag page that exists and at least one example from the gallery, in both locales.

**Japanese pages mirror every change.** Guide link text is each guide's own Japanese title, read from the page; example names stay in English as they already did.

## Verification

- `npm run check:web-components`: 31 tags, 664 rows, 56 events, clean, with the new tail rules. Run against the pages as they stood before this branch, the rules report all 62 pages as lacking a See Also section.
- `npm run lint`: 0 issues in 1328 files.
- `npm run build`: both locales, no broken links or anchors, which covers every new sibling and guide link.

## Reviewer notes

- Sibling reasons are written as fragments, not sentences, so the list scans; the Japanese fragments follow the same convention.
- No screenshot: the change is text at the end of each page, checked on the built output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
