### PR TITLE
docs: distance is the default gsplat LOD mode (en + ja)

### DIFF
--- a/docs/user-manual/gaussian-splatting/building/lod-streaming.md
+++ b/docs/user-manual/gaussian-splatting/building/lod-streaming.md
@@ -45,18 +45,20 @@ Streaming is enabled simply by loading a Streamed SOG asset (`lod-meta.json`) on
 
 ### How LOD Is Chosen
 
-The engine picks one LOD level per region of the scene so that the total splat count fits the global [splat budget](/user-manual/gaussian-splatting/building/performance#global-splat-budget), spending detail where it improves the image the most. It combines each region's projected size on screen with a measure of how much visual error each of its LOD levels would leave. These error metrics are read from `lod-meta.json` when present ([SplatTransform](/user-manual/splat-transform) 3.3 and newer writes them) and are derived automatically from the splat counts otherwise — no configuration is required either way. LOD selection also compensates for the camera's field of view automatically.
+The engine picks one LOD level per region of the scene so that the total splat count fits the global [splat budget](/user-manual/gaussian-splatting/building/performance#global-splat-budget). By default detail is ordered by camera distance: each region steps down through concentric bands around the camera, with the band edges adapting to the budget. With `GSPLAT_LODMODE_ERROR` (see below) the engine instead combines each region's projected size on screen with a measure of how much visual error each of its LOD levels would leave. These error metrics are read from `lod-meta.json` when present ([SplatTransform](/user-manual/splat-transform) 3.3 and newer writes them) and are derived automatically from the splat counts otherwise — no configuration is required either way. LOD selection also compensates for the camera's field of view automatically.
 
 ### LOD Mode
 
 [`lodMode`](https://api.playcanvas.com/engine/classes/GSplatParams.html#lodMode) on `app.scene.gsplat` selects between two strategies:
 
 ```javascript
-app.scene.gsplat.lodMode = pc.GSPLAT_LODMODE_DISTANCE;
+app.scene.gsplat.lodMode = pc.GSPLAT_LODMODE_ERROR;
 ```
 
-- `GSPLAT_LODMODE_ERROR` (default): the budget goes where it removes the most visual error per splat.
-- `GSPLAT_LODMODE_DISTANCE`: error metadata is ignored and detail is ordered by camera distance alone, stepping down in concentric bands around the camera with the band edges adapting to the budget. Useful when a capture's error data does not match its visual importance.
+- `GSPLAT_LODMODE_DISTANCE` (default): error metadata is ignored and detail is ordered by camera distance alone, stepping down in concentric bands around the camera with the band edges adapting to the budget. It uses the least memory of the two modes, so prefer it on memory-constrained devices.
+- `GSPLAT_LODMODE_ERROR`: the budget goes where it removes the most visual error per splat. This lifts sparse, low-quality regions such as sky and distant background that distance alone leaves coarse, but it keeps considerably more source data resident, so memory use is noticeably higher.
+
+Distance mode became the default in engine 2.23; 2.22 defaults to error mode.
 
 ### LOD Falloff
 

--- a/docs/user-manual/gaussian-splatting/building/performance.md
+++ b/docs/user-manual/gaussian-splatting/building/performance.md
@@ -48,10 +48,10 @@ The budget system accounts for all GSplat assets in the scene, including both St
 
 ### LOD Mode and Falloff
 
-Within the budget, LOD levels are picked by measured visual error by default. Two properties fine-tune this — [`lodMode`](https://api.playcanvas.com/engine/classes/GSplatParams.html#lodMode) on `app.scene.gsplat` can switch the whole scene to clean concentric distance bands instead, and [`lodFalloff`](https://api.playcanvas.com/engine/classes/GSplatComponent.html#lodFalloff) on each gsplat component tilts that splat's detail between the near and far field:
+Within the budget, LOD levels are picked by camera distance by default, stepping down in concentric bands around the camera. Two properties fine-tune this — [`lodMode`](https://api.playcanvas.com/engine/classes/GSplatParams.html#lodMode) on `app.scene.gsplat` can switch the whole scene to spending the budget by measured visual error instead, which lifts sparse background regions at a noticeably higher memory cost, and [`lodFalloff`](https://api.playcanvas.com/engine/classes/GSplatComponent.html#lodFalloff) on each gsplat component tilts that splat's detail between the near and far field:
 
 ```javascript
-app.scene.gsplat.lodMode = pc.GSPLAT_LODMODE_DISTANCE;
+app.scene.gsplat.lodMode = pc.GSPLAT_LODMODE_ERROR;
 entity.gsplat.lodFalloff = 2; // more detail near the camera, less in the distance
 ```
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/gaussian-splatting/building/lod-streaming.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/gaussian-splatting/building/lod-streaming.md
@@ -45,18 +45,20 @@ Streamed SOGの動作を確認するには、以下のライブサンプルを�
 
 ### LODの選択方法
 
-エンジンは、合計スプラット数がグローバルな[スプラット予算](/user-manual/gaussian-splatting/building/performance#global-splat-budget)に収まるように、シーンの各領域に1つのLODレベルを選択し、画質への貢献が最も大きい場所に詳細を割り当てます。その際、各領域の画面上での投影サイズと、各LODレベルが残す視覚的誤差の指標を組み合わせて判断します。誤差の指標は、`lod-meta.json`に含まれている場合はそこから読み取られ（[SplatTransform](/user-manual/splat-transform) 3.3以降が書き出します）、含まれていない場合はスプラット数から自動的に導出されるため、どちらの場合も設定は不要です。LOD選択はカメラの視野角（FOV）も自動的に補正します。
+エンジンは、合計スプラット数がグローバルな[スプラット予算](/user-manual/gaussian-splatting/building/performance#global-splat-budget)に収まるように、シーンの各領域に1つのLODレベルを選択します。デフォルトでは、詳細はカメラからの距離に基づいて順序付けられ、各領域はカメラを中心とした同心円状のバンドで段階的に低下し、バンドの境界は予算に応じて調整されます。`GSPLAT_LODMODE_ERROR`（後述）では、代わりに各領域の画面上での投影サイズと、各LODレベルが残す視覚的誤差の指標を組み合わせて判断します。誤差の指標は、`lod-meta.json`に含まれている場合はそこから読み取られ（[SplatTransform](/user-manual/splat-transform) 3.3以降が書き出します）、含まれていない場合はスプラット数から自動的に導出されるため、どちらの場合も設定は不要です。LOD選択はカメラの視野角（FOV）も自動的に補正します。
 
 ### LODモード
 
 `app.scene.gsplat`の[`lodMode`](https://api.playcanvas.com/engine/classes/GSplatParams.html#lodMode)で、2つの戦略を切り替えられます：
 
 ```javascript
-app.scene.gsplat.lodMode = pc.GSPLAT_LODMODE_DISTANCE;
+app.scene.gsplat.lodMode = pc.GSPLAT_LODMODE_ERROR;
 ```
 
-- `GSPLAT_LODMODE_ERROR`（デフォルト）：スプラット1つあたりの視覚的誤差の削減量が最も大きい場所に予算を割り当てます。
-- `GSPLAT_LODMODE_DISTANCE`：誤差メタデータを無視し、カメラからの距離のみに基づいて詳細を順序付けます。詳細はカメラを中心とした同心円状のバンドで段階的に低下し、バンドの境界は予算に応じて調整されます。キャプチャの誤差データが視覚的な重要度と一致しない場合に便利です。
+- `GSPLAT_LODMODE_DISTANCE`（デフォルト）：誤差メタデータを無視し、カメラからの距離のみに基づいて詳細を順序付けます。詳細はカメラを中心とした同心円状のバンドで段階的に低下し、バンドの境界は予算に応じて調整されます。2つのモードのうちメモリ使用量が最も少ないため、メモリに制約のあるデバイスではこちらを推奨します。
+- `GSPLAT_LODMODE_ERROR`：スプラット1つあたりの視覚的誤差の削減量が最も大きい場所に予算を割り当てます。距離だけでは粗いままになる空や遠景などの疎で低品質な領域の品質を引き上げますが、より多くのソースデータをメモリに保持するため、メモリ使用量は著しく増加します。
+
+距離モードはエンジン2.23でデフォルトになりました。2.22ではエラーモードがデフォルトです。
 
 ### LODフォールオフ
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/gaussian-splatting/building/performance.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/gaussian-splatting/building/performance.md
@@ -48,10 +48,10 @@ app.scene.gsplat.splatBudget = 4000000; // 最大400万スプラット
 
 ### LODモードとフォールオフ
 
-バジェットの範囲内では、デフォルトで測定された視覚的誤差に基づいてLODレベルが選択されます。これを微調整する2つのプロパティがあります。`app.scene.gsplat`の[`lodMode`](https://api.playcanvas.com/engine/classes/GSplatParams.html#lodMode)はシーン全体を明確な同心円状の距離バンドによる選択に切り替えられ、各gsplatコンポーネントの[`lodFalloff`](https://api.playcanvas.com/engine/classes/GSplatComponent.html#lodFalloff)はそのスプラットの詳細を近景と遠景の間で傾けられます：
+バジェットの範囲内では、デフォルトでカメラからの距離に基づいてLODレベルが選択され、カメラを中心とした同心円状のバンドで段階的に低下します。これを微調整する2つのプロパティがあります。`app.scene.gsplat`の[`lodMode`](https://api.playcanvas.com/engine/classes/GSplatParams.html#lodMode)はシーン全体を測定された視覚的誤差に基づく予算配分に切り替えられ（疎な背景領域の品質が向上しますが、メモリ使用量は著しく増加します）、各gsplatコンポーネントの[`lodFalloff`](https://api.playcanvas.com/engine/classes/GSplatComponent.html#lodFalloff)はそのスプラットの詳細を近景と遠景の間で傾けられます：
 
 ```javascript
-app.scene.gsplat.lodMode = pc.GSPLAT_LODMODE_DISTANCE;
+app.scene.gsplat.lodMode = pc.GSPLAT_LODMODE_ERROR;
 entity.gsplat.lodFalloff = 2; // カメラ付近の詳細を増やし、遠方の詳細を減らす
 ```
 


### PR DESCRIPTION
Engine 2.23 changes the default `lodMode` for streamed gaussian splats from `GSPLAT_LODMODE_ERROR` to `GSPLAT_LODMODE_DISTANCE` (playcanvas/engine#9326). The LOD streaming and performance pages still described error mode as the default.

**Changes:**
- *How LOD Is Chosen* now describes distance-ordered selection as the default and error-driven selection as what `GSPLAT_LODMODE_ERROR` switches to; the note about `lod-meta.json` error metrics is kept.
- *LOD Mode* lists `GSPLAT_LODMODE_DISTANCE` as the default and recommends it on memory-constrained devices; `GSPLAT_LODMODE_ERROR` is described as lifting sparse, low-quality regions such as sky and distant background at a noticeably higher memory cost. Code samples now show selecting error mode, since that is the non-default choice.
- A one-line version note: distance became the default in engine 2.23, 2.22 defaults to error mode.
- The performance page's *LOD Mode and Falloff* summary is updated to match.
- Japanese pages (`i18n/ja`) mirror every change sentence for sentence.

`markdownlint` passes on all four files.