### PR TITLE
Document WGSL derivatives and the derivative_uniformity diagnostic

### DIFF
--- a/docs/user-manual/graphics/shaders/wgsl-capabilities.md
+++ b/docs/user-manual/graphics/shaders/wgsl-capabilities.md
@@ -47,6 +47,24 @@ When `device.supportsShaderF16` is true, the engine automatically adds the `enab
 
 :::
 
+### Diagnostic Filters {#diagnostic-filters}
+
+Not every optional WGSL directive is device-gated. Diagnostic filters are core WGSL rather than an extension, so there is no `device.supports*` flag or `CAPS_*` define for them, and the engine injects none of them - which leaves the `derivative_uniformity` rule at its default severity of `error` in every generated shader.
+
+That rule rejects `dpdx` / `dpdy` / `fwidth`, `textureSample`, `textureSampleBias` and `textureSampleCompare` calls that the compiler cannot prove run in uniform control flow. A module-scope directive relaxes it:
+
+```wgsl
+diagnostic(off, derivative_uniformity);
+```
+
+:::warning
+
+Browser support is uneven. The module-scope directive above parses everywhere, but the `@diagnostic(…)` attribute form is a shader-creation error on Safari (function and statement scope) and on Firefox (statement scope), so it is not safe to ship. Chrome is also currently the only implementation that enforces the rule at all.
+
+:::
+
+Because a suppressed derivative returns an indeterminate value rather than a correct one, this is a last resort. See [Derivatives and Uniform Control Flow](/user-manual/graphics/shaders/wgsl-specifics#derivatives-and-uniform-control-flow) for the preferred fixes and the full browser support matrix.
+
 ### WGSL language extensions {#wgsl-language-extensions}
 
 At device creation, the engine reads `navigator.gpu.wgslLanguageFeatures` and adds the necessary `enable …;` and `requires …;` directives to generated WGSL so shaders can use optional language features. Your shader source can branch on the matching `CAPS_*` defines (merged with your own `vertexDefines`, `fragmentDefines`, and `cdefines` on the `Shader` definition, where applicable).

--- a/docs/user-manual/graphics/shaders/wgsl-specifics.md
+++ b/docs/user-manual/graphics/shaders/wgsl-specifics.md
@@ -1,0 +1,184 @@
+---
+title: WGSL Specifics
+description: "WGSL language rules that affect PlayCanvas shaders: derivatives and uniform control flow, and the derivative_uniformity diagnostic."
+---
+
+WGSL enforces some rules that have no equivalent in GLSL. This page covers the ones you are most likely to meet when writing custom shaders or shader chunks for WebGPU.
+
+For optional, device-gated WGSL features - half-precision types and language extensions - see [WGSL Capabilities](/user-manual/graphics/shaders/wgsl-capabilities). For the attribute, varying and output conventions the engine expects, see [WGSL Vertex and Fragment Shaders](/user-manual/graphics/shaders/wgsl-vertex-fragment-shaders).
+
+### Derivatives and Uniform Control Flow {#derivatives-and-uniform-control-flow}
+
+GPUs evaluate fragment shaders in 2x2 blocks of pixels called quads, and compute derivatives by differencing values between neighbours in the quad. That only works if every invocation in the quad reaches the same place in the shader together - what WGSL calls **uniform control flow**. If some invocations took a different branch, the neighbouring values are not there to difference and the result is meaningless.
+
+WGSL therefore rejects, at shader creation time, any call to a derivative-dependent built-in that it cannot prove runs in uniform control flow:
+
+- the derivative built-ins: `dpdx`, `dpdy`, `fwidth` (and their `Coarse` / `Fine` variants)
+- `textureSample`
+- `textureSampleBias`
+- `textureSampleCompare`
+
+Control flow is non-uniform when it depends on a value WGSL cannot prove is the same across invocations - an interpolated varying, a built-in such as `position`, a value read from a texture or storage buffer, or a mutable module-scope variable. Branching on a **uniform buffer** value is fine, and so is `#if` / `#ifdef`, because the preprocessor resolves those before the shader is compiled.
+
+The error looks like this:
+
+```text
+error: 'textureSample' must only be called from uniform control flow
+note: control flow depends on possibly non-uniform value
+note: user-defined input 'uv' of 'fragmentMain' may be non-uniform
+```
+
+The notes matter more than the error - they name the value that made the control flow non-uniform, which is usually the fastest route to a fix.
+
+#### Fixing it {#fixing-it}
+
+**1. Restructure so the call is uniform.** Usually the cheapest fix. Hoist the sample out of the branch, or drop the early exit that split the quad:
+
+```wgsl
+// rejected: the sample is only reached by some invocations
+if (mask > 0.5) {
+    color = textureSample(colorMap, colorMapSampler, uv);
+}
+
+// accepted: every invocation samples, the branch only selects
+let sampled = textureSample(colorMap, colorMapSampler, uv);
+color = select(color, sampled, mask > 0.5);
+```
+
+A `discard` on its own is fine, because control flow re-converges after it. Adding a `return` is not, because the code that follows is then reached by only some invocations:
+
+```wgsl
+// accepted: no early return, so later sampling is still uniform
+if (alpha < threshold) {
+    discard;
+}
+
+// rejected: everything after this is non-uniform
+if (alpha < threshold) {
+    discard;
+    return output;
+}
+```
+
+**2. Sample at an explicit level or gradient.** `textureSampleLevel`, `textureSampleGrad` and `textureSampleCompareLevel` need no implicit derivative, so they are legal anywhere. This is what the engine's own chunks do: shadow map taps, the cookie atlas, lighting LUTs and post-processing all sample at an explicit level, since those textures have no mipmaps to select between anyway.
+
+```wgsl
+// legal in any control flow
+color = textureSampleLevel(colorMap, colorMapSampler, uv, 0.0);
+```
+
+Where you do want a mip level, compute it once in uniform control flow and pass it in - a loop that marches across a texture wants a fixed level regardless:
+
+```wgsl
+let sizeInTexels = vec2f(textureDimensions(heightMap, 0));
+let uvTexels = uv * sizeInTexels;
+let dx = dpdx(uvTexels);
+let dy = dpdy(uvTexels);
+let lod = max(0.0, 0.5 * log2(max(dot(dx, dx), dot(dy, dy))));
+
+for (var i = 0.0; i < steps; i += 1.0) {
+    let h = textureSampleLevel(heightMap, heightMapSampler, marchUv, lod).x;
+    // ...
+}
+```
+
+**3. Suppress the diagnostic.** A last resort - see below.
+
+### The derivative_uniformity Diagnostic {#the-derivative-uniformity-diagnostic}
+
+`derivative_uniformity` is one of two filterable WGSL diagnostic rules, and its default severity is `error`. A diagnostic filter changes that severity, which makes the code above compile.
+
+:::warning
+
+Support for diagnostic filters differs sharply between browsers, and the attribute form is a **shader-creation error** on some of them. Only the module-scope directive is portable today - see [Browser Support](#browser-support) before using any of this.
+
+:::
+
+A filter can be applied to a whole module as a directive, or to a function, statement or block as an attribute:
+
+```wgsl
+// module scope - portable. Must precede every declaration in the module.
+diagnostic(off, derivative_uniformity);
+
+// function scope - rejected by Safari
+@diagnostic(off, derivative_uniformity)
+fn readHeight(uv: vec2f) -> f32 {
+    return textureSample(heightMap, heightMapSampler, uv).x;
+}
+
+// statement scope - rejected by Safari and Firefox
+@diagnostic(off, derivative_uniformity) if (mask > 0.5) {
+    color = textureSample(colorMap, colorMapSampler, uv);
+}
+```
+
+Suppressing the diagnostic does not make the derivative correct. The WGSL specification says a derivative built-in called in non-uniform control flow "returns an indeterminate value" - an arbitrary implementation-chosen value which, for a floating-point type, may be a NaN. It cannot corrupt memory or lose the device, but a NaN mip level or normal can propagate into the framebuffer as an artifact that varies between GPUs. Prefer restructuring the shader, or sampling at an explicit level.
+
+### Browser Support {#browser-support}
+
+Measured September 2026 on Chrome 148, Firefox 154 and Safari 26.6.2, macOS / Apple GPU:
+
+| | Chrome (Dawn) | Firefox (naga) | Safari (WebKit) |
+|---|---|---|---|
+| Enforces `derivative_uniformity` | Yes, as an error | No | No |
+| `diagnostic(…)` directive at module scope | Honoured | Parsed, no effect | Parsed, no effect |
+| `@diagnostic(…)` on a function | Honoured | Parsed, no effect | **Shader-creation error** |
+| `@diagnostic(…)` on a statement or block | Honoured | **Shader-creation error** | **Shader-creation error** |
+| Conflicting directives rejected | Yes | Yes | No |
+| Unrecognised rule name | Warning, rule still applies | Accepted silently | Accepted silently |
+
+Two consequences worth planning around:
+
+- **Chrome is currently the only implementation that enforces the rule.** A shader that samples in non-uniform control flow compiles on Firefox and Safari and fails only on Chrome, so develop against Chrome if you want the violation surfaced. Write for the strictest implementation - the others may start enforcing it at any time, since an error is what the specification requires.
+- **Only the module-scope directive is portable.** Firefox rejects a statement-scope attribute outright (`@diagnostic(…) attribute(s) not yet implemented`), and Safari rejects both the statement and function forms (`invalid attribute for function declaration`). A single `@diagnostic` on a function is therefore enough to break a shader on Safari, even though it is exactly the narrow, well-scoped choice the specification intends.
+
+#### Scope Rules {#scope-rules}
+
+These rules describe Chrome, the only implementation that acts on the filter. They still matter, because Chrome is where you will see the error.
+
+The filter must be in scope **at the call site of the built-in** - not at the branch that made control flow non-uniform - and it is not inherited by functions you call. This is the most common mistake:
+
+```wgsl
+// does NOT work - the attribute is on the entry point, but the
+// textureSample call is inside readHeight
+@diagnostic(off, derivative_uniformity)
+@fragment
+fn fragmentMain(input: FragmentInput) -> FragmentOutput {
+    if (input.mask > 0.5) {
+        h = readHeight(uv);   // still an error, reported inside readHeight
+    }
+    // ...
+}
+
+// works - the attribute is on the function that contains the call
+@diagnostic(off, derivative_uniformity)
+fn readHeight(uv: vec2f) -> f32 {
+    return textureSample(heightMap, heightMapSampler, uv).x;
+}
+```
+
+Summarised, for a `textureSample` that lives inside a helper function called from a non-uniform branch:
+
+| Attribute placement | Effect on Chrome |
+|---|---|
+| On the helper function that contains the call | Suppressed |
+| On the entry point function only | **Still an error** |
+| On the `if` statement that calls the helper | **Still an error** |
+| On the block that calls the helper | **Still an error** |
+| On the helper, when the call is one level deeper still | **Still an error** |
+
+A statement-scope attribute does suppress a `textureSample` written directly inside it - an `if`, a `for` loop or a plain block all work - but that form is rejected by both Firefox and Safari, so it is not usable in shipped shaders.
+
+#### Other Behaviour Worth Knowing {#other-behaviour-worth-knowing}
+
+- **Placement.** A module-scope `diagnostic(…)` directive must come before every module-scope declaration, alongside any `enable` and `requires` directives. The order among the directives themselves does not matter, and all three browsers agree on this. The engine prepends its own `enable` / `requires` lines ahead of your source, so put yours at the very top of the chunk - before any `const`, `struct`, `var` or `fn`.
+- **Severities.** The available severities are `off`, `info`, `warning` and `error`. On Chrome, `info` and `warning` let the shader compile while still reporting the message through `getCompilationInfo()`, which is useful for auditing. The other two browsers do not report them.
+- **Re-arming is Chrome-only.** A narrower `@diagnostic(error, derivative_uniformity)` restores the error inside a module that switched it off, which would let you keep the check active for most of a shader while exempting one function. It relies on the function-attribute form, so it cannot be used portably.
+- **Conflicts are fatal.** Two module-scope directives that set the same rule to *different* severities is a shader-creation error on Chrome and Firefox. Repeating the *same* severity is fine everywhere. This matters if you add a module-scope directive to a chunk that is combined with others.
+- **Typos fail loudly only on Chrome.** An unrecognised rule name produces a warning naming the valid rules there, and the original error still fires. Firefox and Safari accept a misspelled rule name silently.
+
+:::note
+
+PlayCanvas does not inject any `diagnostic(…)` directive into generated WGSL, so `derivative_uniformity` is an error by default in every shader on Chrome. The engine's own chunks satisfy the rule by sampling at an explicit level rather than by suppressing the diagnostic, which keeps them portable.
+
+:::

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -73,8 +73,6 @@ const config = {
         { from: ['/user-manual/getting-started/workflow/'], to: '/user-manual/editor/getting-started/workflow/' },
         { from: ['/user-manual/getting-started/your-first-app/'], to: '/user-manual/editor/getting-started/your-first-app/' },
         { from: ['/user-manual/graphics/gaussian-splatting/'], to: '/user-manual/gaussian-splatting/' },
-        // WGSL Specifics renamed/split: shared resource reflection now lives on its own page
-        { from: ['/user-manual/graphics/shaders/wgsl-specifics/'], to: '/user-manual/graphics/shaders/wgsl-reflection/' },
         // Gaussian splatting: unified-rendering merged into the rendering-architecture page (now its own section)
         { from: ['/user-manual/gaussian-splatting/building/unified-rendering/'], to: '/user-manual/gaussian-splatting/rendering-architecture/' },
         { from: ['/user-manual/gaussian-splatting/building/rendering-architecture/'], to: '/user-manual/gaussian-splatting/rendering-architecture/' },

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/shaders/wgsl-capabilities.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/shaders/wgsl-capabilities.md
@@ -47,6 +47,24 @@ output.color = vec4f(vec3f(result), 1.0);
 
 :::
 
+### 診断フィルタ {#diagnostic-filters}
+
+任意の WGSL ディレクティブがすべてデバイス依存というわけではありません。診断フィルタは拡張ではなく WGSL のコア機能であるため、`device.supports*` フラグや `CAPS_*` 定義は存在せず、エンジンもこれを一切注入しません。その結果、`derivative_uniformity` ルールは生成されるすべてのシェーダーで既定の深刻度 `error` のままになります。
+
+このルールは、一様な制御フローで実行されることをコンパイラが証明できない `dpdx` / `dpdy` / `fwidth`、`textureSample`、`textureSampleBias`、`textureSampleCompare` の呼び出しを拒否します。モジュールスコープのディレクティブでこれを緩められます。
+
+```wgsl
+diagnostic(off, derivative_uniformity);
+```
+
+:::warning
+
+ブラウザのサポート状況は不均一です。上記のモジュールスコープのディレクティブはどの環境でも解析されますが、`@diagnostic(…)` の属性形式は Safari（関数スコープと文スコープ）および Firefox（文スコープ）でシェーダー作成エラーになるため、出荷するコードでは使用できません。また、現時点でこのルールを実際に強制しているのは Chrome だけです。
+
+:::
+
+抑制された微分は正しい値ではなく不定値を返すため、これは最後の手段です。推奨される修正方法とブラウザのサポート状況の一覧は [微分と一様な制御フロー](/user-manual/graphics/shaders/wgsl-specifics#derivatives-and-uniform-control-flow) を参照してください。
+
 ### WGSL 言語拡張 {#wgsl-language-extensions}
 
 デバイス作成時に、エンジンは `navigator.gpu.wgslLanguageFeatures` を読み取り、任意の言語機能用に必要な `enable …;` および `requires …;` ディレクティブを生成される WGSL に付加します。シェーダー側では、対応する `CAPS_*` 定義（`Shader` 定義の `vertexDefines` / `fragmentDefines` / `cdefines` とマージ）で分岐できます。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/shaders/wgsl-specifics.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/shaders/wgsl-specifics.md
@@ -1,0 +1,184 @@
+---
+title: WGSL の詳細
+description: "PlayCanvas のシェーダーに影響する WGSL 固有の言語ルール：微分と一様な制御フロー、および derivative_uniformity 診断。"
+---
+
+WGSL には GLSL に相当するものが存在しないルールがいくつかあります。このページでは、WebGPU 向けにカスタムシェーダーやシェーダーチャンクを記述する際に遭遇しやすいものを扱います。
+
+デバイスのサポートに依存する任意の WGSL 機能（半精度型や言語拡張）については [WGSL ケイパビリティ](/user-manual/graphics/shaders/wgsl-capabilities) を参照してください。エンジンが期待する attribute、varying、出力の規約については [WGSL 頂点シェーダーとフラグメントシェーダー](/user-manual/graphics/shaders/wgsl-vertex-fragment-shaders) を参照してください。
+
+### 微分と一様な制御フロー {#derivatives-and-uniform-control-flow}
+
+GPU はフラグメントシェーダーを 2x2 ピクセルのブロック（クアッド）単位で評価し、クアッド内の隣接ピクセルとの差分をとることで微分を求めます。これが成立するのは、クアッド内のすべての呼び出しがシェーダー内の同じ位置に一緒に到達している場合だけです。WGSL ではこれを**一様な制御フロー（uniform control flow）**と呼びます。一部の呼び出しが別の分岐に進んでいると、差分をとるべき隣接値が存在せず、結果は無意味になります。
+
+そのため WGSL は、一様な制御フローで実行されることを証明できない微分依存の組み込み関数の呼び出しを、シェーダー作成時に拒否します。
+
+- 微分組み込み関数: `dpdx`、`dpdy`、`fwidth`（および `Coarse` / `Fine` の各バリアント）
+- `textureSample`
+- `textureSampleBias`
+- `textureSampleCompare`
+
+制御フローが非一様になるのは、呼び出し間で同一であることを WGSL が証明できない値に依存している場合です。補間された varying、`position` などの組み込み値、テクスチャやストレージバッファから読み取った値、書き換え可能なモジュールスコープ変数などが該当します。**ユニフォームバッファ**の値による分岐は問題ありません。`#if` / `#ifdef` も、シェーダーのコンパイル前にプリプロセッサが解決するため問題ありません。
+
+エラーは次のような形で現れます。
+
+```text
+error: 'textureSample' must only be called from uniform control flow
+note: control flow depends on possibly non-uniform value
+note: user-defined input 'uv' of 'fragmentMain' may be non-uniform
+```
+
+エラー本文よりも note の方が重要です。制御フローを非一様にした値の名前が示されており、多くの場合これが修正への最短経路になります。
+
+#### 修正方法 {#fixing-it}
+
+**1. 呼び出しが一様になるように構造を変える。** 通常はこれが最も低コストな修正です。サンプリングを分岐の外に持ち上げるか、クアッドを分断している早期終了を取り除きます。
+
+```wgsl
+// 拒否される: 一部の呼び出しだけがサンプリングに到達する
+if (mask > 0.5) {
+    color = textureSample(colorMap, colorMapSampler, uv);
+}
+
+// 受理される: すべての呼び出しがサンプリングし、分岐は選択のみを行う
+let sampled = textureSample(colorMap, colorMapSampler, uv);
+color = select(color, sampled, mask > 0.5);
+```
+
+`discard` 単独であれば、その後で制御フローが再収束するため問題ありません。しかし `return` を加えると、以降のコードに到達するのが一部の呼び出しだけになるため許されません。
+
+```wgsl
+// 受理される: 早期 return がないため、以降のサンプリングも一様なまま
+if (alpha < threshold) {
+    discard;
+}
+
+// 拒否される: これ以降がすべて非一様になる
+if (alpha < threshold) {
+    discard;
+    return output;
+}
+```
+
+**2. 明示的なレベルまたは勾配でサンプリングする。** `textureSampleLevel`、`textureSampleGrad`、`textureSampleCompareLevel` は暗黙の微分を必要としないため、どの制御フローでも使用できます。エンジン自身のチャンクもこの方法を採っています。シャドウマップのタップ、クッキーアトラス、ライティング LUT、ポストプロセスはいずれも明示的なレベルでサンプリングしており、そもそもこれらのテクスチャには選択対象となるミップマップがありません。
+
+```wgsl
+// どの制御フローでも合法
+color = textureSampleLevel(colorMap, colorMapSampler, uv, 0.0);
+```
+
+ミップレベルが必要な場合は、一様な制御フロー内で一度だけ計算して渡します。テクスチャ上を進むループでは、いずれにせよ固定されたレベルを使うのが望ましい動作です。
+
+```wgsl
+let sizeInTexels = vec2f(textureDimensions(heightMap, 0));
+let uvTexels = uv * sizeInTexels;
+let dx = dpdx(uvTexels);
+let dy = dpdy(uvTexels);
+let lod = max(0.0, 0.5 * log2(max(dot(dx, dx), dot(dy, dy))));
+
+for (var i = 0.0; i < steps; i += 1.0) {
+    let h = textureSampleLevel(heightMap, heightMapSampler, marchUv, lod).x;
+    // ...
+}
+```
+
+**3. 診断を抑制する。** 最後の手段です。以下を参照してください。
+
+### derivative_uniformity 診断 {#the-derivative-uniformity-diagnostic}
+
+`derivative_uniformity` は、WGSL でフィルタリング可能な 2 つの診断ルールのうちの 1 つで、既定の深刻度は `error` です。診断フィルタでこの深刻度を変更すると、上記のコードもコンパイルできるようになります。
+
+:::warning
+
+診断フィルタのサポート状況はブラウザによって大きく異なり、属性形式は一部のブラウザでは**シェーダー作成エラー**になります。現時点で移植性があるのはモジュールスコープのディレクティブのみです。利用する前に必ず [ブラウザのサポート状況](#browser-support) を確認してください。
+
+:::
+
+フィルタは、ディレクティブとしてモジュール全体に、または属性として関数・文・ブロックに適用できます。
+
+```wgsl
+// モジュールスコープ - 移植性あり。モジュール内のすべての宣言より前に置く必要がある。
+diagnostic(off, derivative_uniformity);
+
+// 関数スコープ - Safari では拒否される
+@diagnostic(off, derivative_uniformity)
+fn readHeight(uv: vec2f) -> f32 {
+    return textureSample(heightMap, heightMapSampler, uv).x;
+}
+
+// 文スコープ - Safari と Firefox で拒否される
+@diagnostic(off, derivative_uniformity) if (mask > 0.5) {
+    color = textureSample(colorMap, colorMapSampler, uv);
+}
+```
+
+診断を抑制しても、微分が正しくなるわけではありません。WGSL 仕様では、非一様な制御フローで呼び出された微分組み込み関数は「不定値（indeterminate value）を返す」と定義されています。これは実装が任意に選ぶ値であり、浮動小数点型の場合は NaN になることもあります。メモリを破壊したりデバイスを失ったりすることはありませんが、NaN のミップレベルや法線がフレームバッファまで伝播し、GPU によって見え方が変わるアーティファクトとして現れる可能性があります。シェーダーの構造を変えるか、明示的なレベルでサンプリングする方法を優先してください。
+
+### ブラウザのサポート状況 {#browser-support}
+
+2026 年 9 月時点、macOS / Apple GPU 上の Chrome 148、Firefox 154、Safari 26.6.2 で計測した結果です。
+
+| | Chrome (Dawn) | Firefox (naga) | Safari (WebKit) |
+|---|---|---|---|
+| `derivative_uniformity` を強制するか | する（エラー） | しない | しない |
+| モジュールスコープの `diagnostic(…)` ディレクティブ | 反映される | 解析されるが無効果 | 解析されるが無効果 |
+| 関数に付けた `@diagnostic(…)` | 反映される | 解析されるが無効果 | **シェーダー作成エラー** |
+| 文・ブロックに付けた `@diagnostic(…)` | 反映される | **シェーダー作成エラー** | **シェーダー作成エラー** |
+| 競合するディレクティブを拒否するか | する | する | しない |
+| 認識できないルール名 | 警告。ルールは適用され続ける | 黙って受理 | 黙って受理 |
+
+計画時に押さえておきたい点が 2 つあります。
+
+- **現時点でこのルールを強制しているのは Chrome だけです。** 非一様な制御フローでサンプリングするシェーダーは Firefox と Safari ではコンパイルでき、Chrome でのみ失敗します。違反を検出したい場合は Chrome を基準に開発してください。仕様が求めているのはエラーであり、他の実装もいつ強制を始めるか分からないため、最も厳しい実装に合わせて記述してください。
+- **移植性があるのはモジュールスコープのディレクティブのみです。** Firefox は文スコープの属性を明確に拒否し（`@diagnostic(…) attribute(s) not yet implemented`）、Safari は文スコープと関数スコープの両方を拒否します（`invalid attribute for function declaration`）。したがって、関数に `@diagnostic` を 1 つ付けるだけで Safari 上のシェーダーが壊れます。仕様が意図している範囲を絞った適切な指定であるにもかかわらず、そうなります。
+
+#### スコープのルール {#scope-rules}
+
+以下のルールは、フィルタを実際に反映する唯一の実装である Chrome の挙動を説明したものです。エラーが表示されるのは Chrome であるため、これらは依然として重要です。
+
+フィルタは、制御フローを非一様にした分岐ではなく、**組み込み関数の呼び出し箇所**でスコープに入っている必要があります。また、呼び出し先の関数には継承されません。これが最もよくある間違いです。
+
+```wgsl
+// 機能しない - 属性はエントリポイントに付いているが、
+// textureSample の呼び出しは readHeight の中にある
+@diagnostic(off, derivative_uniformity)
+@fragment
+fn fragmentMain(input: FragmentInput) -> FragmentOutput {
+    if (input.mask > 0.5) {
+        h = readHeight(uv);   // 依然としてエラー。readHeight 内で報告される
+    }
+    // ...
+}
+
+// 機能する - 属性が呼び出しを含む関数に付いている
+@diagnostic(off, derivative_uniformity)
+fn readHeight(uv: vec2f) -> f32 {
+    return textureSample(heightMap, heightMapSampler, uv).x;
+}
+```
+
+非一様な分岐から呼ばれるヘルパー関数の中に `textureSample` がある場合をまとめると、次のようになります。
+
+| 属性の位置 | Chrome での結果 |
+|---|---|
+| 呼び出しを含むヘルパー関数 | 抑制される |
+| エントリポイント関数のみ | **依然としてエラー** |
+| ヘルパーを呼び出す `if` 文 | **依然としてエラー** |
+| ヘルパーを呼び出すブロック | **依然としてエラー** |
+| ヘルパー（ただし呼び出しがさらに 1 段深い場合） | **依然としてエラー** |
+
+文スコープの属性は、その構文内に直接書かれた `textureSample` を抑制します（`if`、`for` ループ、単純なブロックのいずれでも機能します）。ただしこの形式は Firefox と Safari の両方で拒否されるため、実際に出荷するシェーダーでは使用できません。
+
+#### そのほか把握しておきたい挙動 {#other-behaviour-worth-knowing}
+
+- **配置。** モジュールスコープの `diagnostic(…)` ディレクティブは、`enable` や `requires` ディレクティブと並んで、すべてのモジュールスコープ宣言より前に置く必要があります。ディレクティブ同士の順序は問われず、この点は 3 つのブラウザすべてで一致しています。エンジンは自身の `enable` / `requires` 行をソースの前に付加するため、独自のディレクティブはチャンクの最上部、つまり `const`、`struct`、`var`、`fn` のいずれよりも前に記述してください。
+- **深刻度。** 指定できる深刻度は `off`、`info`、`warning`、`error` です。Chrome では `info` と `warning` はシェーダーをコンパイルさせつつ、メッセージを `getCompilationInfo()` 経由で報告し続けるため、監査目的に有用です。他の 2 つのブラウザはこれらを報告しません。
+- **再有効化は Chrome 限定。** より狭い範囲の `@diagnostic(error, derivative_uniformity)` は、モジュール全体でオフにした診断をその範囲でエラーに戻すため、シェーダーの大部分ではチェックを有効に保ちながら特定の関数だけを除外できます。ただし関数属性の形式に依存するため、移植性のある形では利用できません。
+- **競合は致命的。** 同じルールに対して*異なる*深刻度を設定するモジュールスコープのディレクティブが 2 つあると、Chrome と Firefox ではシェーダー作成エラーになります。*同じ*深刻度の繰り返しはどの環境でも問題ありません。この点は、他のチャンクと組み合わされるチャンクにモジュールスコープのディレクティブを追加する場合に重要です。
+- **タイプミスが明示的に失敗するのは Chrome のみ。** 認識できないルール名は、Chrome では有効なルール名を示す警告を生成し、元のエラーもそのまま発生します。Firefox と Safari はつづりを誤ったルール名を黙って受理します。
+
+:::note
+
+PlayCanvas は生成される WGSL に `diagnostic(…)` ディレクティブを一切注入しないため、Chrome では `derivative_uniformity` がすべてのシェーダーで既定どおりエラーになります。エンジン自身のチャンクは、診断を抑制するのではなく明示的なレベルでサンプリングすることでこのルールを満たしており、それにより移植性が保たれています。
+
+:::

--- a/sidebars.js
+++ b/sidebars.js
@@ -825,6 +825,7 @@ const sidebars = {
           items: [
             'user-manual/graphics/shaders/preprocessor',
             'user-manual/graphics/shaders/glsl-specifics',
+            'user-manual/graphics/shaders/wgsl-specifics',
             'user-manual/graphics/shaders/wgsl-reflection',
             'user-manual/graphics/shaders/wgsl-capabilities',
             'user-manual/graphics/shaders/wgsl-vertex-fragment-shaders',


### PR DESCRIPTION
Adds a WGSL Specifics page covering derivatives and uniform control flow - the rule that rejects `textureSample` and friends inside a non-uniform branch, which is one of the more confusing errors to hit when writing custom WGSL chunks.

**Changes:**
- New **WGSL Specifics** page (`docs/user-manual/graphics/shaders/wgsl-specifics.md`), sitting next to GLSL Specifics in the sidebar:
  - which built-ins are affected (`dpdx` / `dpdy` / `fwidth`, `textureSample`, `textureSampleBias`, `textureSampleCompare`), what makes control flow non-uniform, and what the error looks like
  - the three fixes in priority order: restructure so the call is uniform, sample at an explicit level or gradient, and only as a last resort suppress the diagnostic
  - the `derivative_uniformity` diagnostic filter, its severities, and the scoping rule that catches people out - the filter must be in scope at the **built-in's call site**, not at the branch that made control flow non-uniform, and it is not inherited by callees
  - a browser support matrix, measured on Chrome 148, Firefox 154 and Safari 26.6.2
- New **Diagnostic Filters** section on WGSL Capabilities, explaining why the rule has no `device.supports*` flag or `CAPS_*` define, and cross-linking the new page
- Japanese translations for both
- Removes the superseded `wgsl-specifics` -> `wgsl-reflection` redirect, now that the slug is in use again. Old inbound links land on the new page rather than on WGSL Reflection; the two are adjacent enough that readers can navigate from there

**Notable findings the page records:**
- **Chrome is currently the only implementation that enforces `derivative_uniformity`.** A shader that samples in non-uniform control flow compiles on Firefox and Safari and fails only on Chrome, so the page tells authors to develop against Chrome and write for the strictest implementation
- **Only the module-scope `diagnostic(...)` directive is portable.** The `@diagnostic(...)` attribute form is a shader-creation error on Safari (function and statement scope) and on Firefox (statement scope), so the narrow, spec-intended per-function filter cannot be shipped today
- Suppressing the diagnostic yields an *indeterminate value* per the WGSL spec, possibly a NaN - documented as a correctness hazard rather than a free switch

No engine behaviour changes: PlayCanvas injects no `diagnostic(...)` directive, and the engine's own chunks satisfy the rule by sampling at an explicit level, which is what keeps them portable.