### PR TITLE
Document per-attachment clear colors for multiple render targets

### DIFF
--- a/docs/user-manual/graphics/advanced-rendering/multiple-render-targets.md
+++ b/docs/user-manual/graphics/advanced-rendering/multiple-render-targets.md
@@ -10,8 +10,8 @@ MRT is supported on every device PlayCanvas runs on (WebGL2 and WebGPU). To dete
 Multiple render targets have the following restrictions:
 
 - All color attachments of a multiple render target must have the same width and height.
-- All color attachments are cleared to the same value, specified using [`CameraComponent.clearColor`](https://api.playcanvas.com/engine/classes/CameraComponent.html#clearcolor).
-- All color attachments use the same write mask and alpha blend mode, as specified using [`BlendState`](https://api.playcanvas.com/engine/classes/BlendState.html).
+- Color attachments are cleared to [`CameraComponent.clearColor`](https://api.playcanvas.com/engine/classes/CameraComponent.html#clearcolor), unless given their own clear color using [`CameraComponent.setClearColor`](https://api.playcanvas.com/engine/classes/CameraComponent.html#setclearcolor), described in [Clear Colors](#clear-colors) below.
+- All color attachments use the same write mask and alpha blend mode, as specified using [`BlendState`](https://api.playcanvas.com/engine/classes/BlendState.html), unless the device reports [`GraphicsDevice.supportsIndependentBlending`](https://api.playcanvas.com/engine/classes/GraphicsDevice.html#supportsindependentblending), in which case [`BlendState.setAttachment`](https://api.playcanvas.com/engine/classes/BlendState.html#setattachment) gives an attachment its own.
 - [Dual-source blending](/user-manual/graphics/advanced-rendering/dual-source-blending) cannot be used with MRT because it requires exactly one color attachment.
 
 ## How to use MRT
@@ -62,6 +62,21 @@ app.root.addChild(entity);
 entity.camera.setShaderPass('MyMRT');
 ```
 
+### Clear Colors
+
+At the start of the camera's rendering, every color attachment is cleared to the camera's [`clearColor`](https://api.playcanvas.com/engine/classes/CameraComponent.html#clearcolor). When the attachments hold different kinds of data, give each its own clear color using [`CameraComponent.setClearColor`](https://api.playcanvas.com/engine/classes/CameraComponent.html#setclearcolor), passing the index of the color attachment. For an integer format attachment, the color components are the integer values to clear to.
+
+```javascript
+// attachment 0 keeps clearing to entity.camera.clearColor
+// clear the normals attachment to a neutral normal, and the gloss attachment to black
+entity.camera.setClearColor(1, new pc.Color(0.5, 0.5, 1, 1));
+entity.camera.setClearColor(2, new pc.Color(0, 0, 0, 1));
+```
+
+Pass `null` to remove the clear color of an attachment, so that it clears to `clearColor` again, and use [`CameraComponent.getClearColor`](https://api.playcanvas.com/engine/classes/CameraComponent.html#getclearcolor) to read the color an attachment clears to.
+
+The per-attachment clear colors apply to the clear at the start of the camera's rendering. Clears performed during rendering - by a [`Layer`](https://api.playcanvas.com/engine/classes/Layer.html) with `clearColorBuffer` enabled, or by a camera whose `rect` does not cover the whole render target - do not support per-attachment colors, and are best avoided with multiple render targets.
+
 ### Standard Materials
 
 When rendering using [`StandardMaterial`](https://api.playcanvas.com/engine/classes/StandardMaterial.html) into Multiple Render Targets (MRT), override the `outputPS` shader chunk to direct values to the additional color buffers. Supply the chunk for each shader language your project targets — GLSL for WebGL2, WGSL for WebGPU. Apply both to every material in your target entity's render components, using [`Material.getShaderChunks`](https://api.playcanvas.com/engine/classes/Material.html#getshaderchunks):
@@ -111,6 +126,6 @@ To restrict the modification to a specific camera, gate it behind the shader pas
 
 ## Example
 
-A full working sample is available in the engine examples: Multiple Render Targets renders a chess board through a custom shader pass that writes its world normal and gloss into additional color targets, displayed on screen as separate textures.
+A full working sample is available in the engine examples: Multiple Render Targets renders a chess board through a custom shader pass that writes its world normal and gloss into additional color targets, each with its own clear color, displayed on screen as separate textures.
 
 <EngineExample id="graphics/multi-render-targets" title="Multiple Render Targets" />

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/advanced-rendering/multiple-render-targets.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/advanced-rendering/multiple-render-targets.md
@@ -10,8 +10,8 @@ MRTは、PlayCanvasが動作するすべてのデバイス（WebGL2およびWebG
 複数のレンダーターゲットには、以下の制限があります。
 
 - 複数のレンダーターゲットのすべてのカラーアタッチメントは、同じ幅と高さを持ちます。
-- すべてのカラーアタッチメントは、[`CameraComponent.clearColor`](https://api.playcanvas.com/engine/classes/CameraComponent.html#clearcolor)を使用して指定された同じ値にクリアされます。
-- すべてのカラーアタッチメントは、[`BlendState`](https://api.playcanvas.com/engine/classes/BlendState.html)を使用して指定された同じ書き込みマスクとアルファブレンドモードを使用します。
+- カラーアタッチメントは、[`CameraComponent.setClearColor`](https://api.playcanvas.com/engine/classes/CameraComponent.html#setclearcolor)で個別のクリアカラーが指定されていない限り、[`CameraComponent.clearColor`](https://api.playcanvas.com/engine/classes/CameraComponent.html#clearcolor)にクリアされます。詳細は後述の[クリアカラー](#クリアカラー)を参照してください。
+- すべてのカラーアタッチメントは、[`BlendState`](https://api.playcanvas.com/engine/classes/BlendState.html)を使用して指定された同じ書き込みマスクとアルファブレンドモードを使用します。ただし、デバイスが[`GraphicsDevice.supportsIndependentBlending`](https://api.playcanvas.com/engine/classes/GraphicsDevice.html#supportsindependentblending)を報告する場合は、[`BlendState.setAttachment`](https://api.playcanvas.com/engine/classes/BlendState.html#setattachment)でアタッチメントごとに個別の設定ができます。
 - [デュアルソースブレンディング](/user-manual/graphics/advanced-rendering/dual-source-blending)にはカラーアタッチメントが 1 つだけ必要なため、MRT と組み合わせることはできません。
 
 ## MRTの使用方法
@@ -62,6 +62,21 @@ app.root.addChild(entity);
 entity.camera.setShaderPass('MyMRT');
 ```
 
+### クリアカラー
+
+カメラのレンダリング開始時に、すべてのカラーアタッチメントはカメラの[`clearColor`](https://api.playcanvas.com/engine/classes/CameraComponent.html#clearcolor)にクリアされます。アタッチメントに異なる種類のデータを格納する場合は、[`CameraComponent.setClearColor`](https://api.playcanvas.com/engine/classes/CameraComponent.html#setclearcolor)にカラーアタッチメントのインデックスを渡して、それぞれに個別のクリアカラーを指定します。整数フォーマットのアタッチメントでは、カラーの各成分がクリアする整数値になります。
+
+```javascript
+// アタッチメント0は引き続きentity.camera.clearColorにクリアされます
+// 法線アタッチメントを中立な法線に、グロスアタッチメントを黒にクリアします
+entity.camera.setClearColor(1, new pc.Color(0.5, 0.5, 1, 1));
+entity.camera.setClearColor(2, new pc.Color(0, 0, 0, 1));
+```
+
+`null`を渡すとアタッチメントのクリアカラーが削除され、再び`clearColor`にクリアされます。アタッチメントがクリアされる色は[`CameraComponent.getClearColor`](https://api.playcanvas.com/engine/classes/CameraComponent.html#getclearcolor)で取得できます。
+
+アタッチメントごとのクリアカラーは、カメラのレンダリング開始時のクリアに適用されます。レンダリング中に行われるクリア — `clearColorBuffer`を有効にした[`Layer`](https://api.playcanvas.com/engine/classes/Layer.html)によるものや、`rect`がレンダーターゲット全体を覆わないカメラによるもの — はアタッチメントごとのカラーをサポートしないため、複数のレンダーターゲットでは避けるのが最善です。
+
 ### 標準マテリアル
 
 [`StandardMaterial`](https://api.playcanvas.com/engine/classes/StandardMaterial.html)を使用して複数のレンダーターゲット (MRT) にレンダリングする場合、追加のカラーバッファに値を出力するために`outputPS`シェーダーチャンクをオーバーライドします。プロジェクトが対象とするシェーダー言語ごとにチャンクを用意してください — WebGL2にはGLSL、WebGPUにはWGSLです。[`Material.getShaderChunks`](https://api.playcanvas.com/engine/classes/Material.html#getshaderchunks)を使って、両方のチャンクを対象エンティティのレンダーコンポーネントのすべてのマテリアルに適用します。
@@ -111,6 +126,6 @@ renders.forEach((render) => {
 
 ## 例
 
-完全に動作するサンプルがエンジンの例にあります: Multiple Render Targets は、カスタムシェーダーパスを通してチェス盤をレンダリングし、ワールド法線とグロスを追加のカラーターゲットに書き込んで、それぞれを画面上に別々のテクスチャとして表示します。
+完全に動作するサンプルがエンジンの例にあります: Multiple Render Targets は、カスタムシェーダーパスを通してチェス盤をレンダリングし、ワールド法線とグロスをそれぞれ個別のクリアカラーを持つ追加のカラーターゲットに書き込んで、それぞれを画面上に別々のテクスチャとして表示します。
 
 <EngineExample id="graphics/multi-render-targets" title="Multiple Render Targets" />


### PR DESCRIPTION
> [!WARNING]
> **Merge only after PlayCanvas Engine 2.23 has been released.**
> This page documents `CameraComponent.setClearColor` / `getClearColor` from playcanvas/engine#9333, which land in 2.23, and links to their API reference.

Re-lands #1188, which was merged early and reverted in #1190. Same content.

Updates the Multiple Render Targets page (en + ja) for per-attachment clear colors on the camera.

**Changes:**
- New **Clear Colors** section: attachments clear to `clearColor` by default, `setClearColor(index, color)` gives an attachment its own color, `null` removes it again, `getClearColor(index)` reads it, integer format attachments take the raw integer values, and clears performed mid-rendering (a layer with `clearColorBuffer`, or a camera `rect` not covering the target) do not support per-attachment colors.
- Restrictions list: the "all attachments are cleared to the same value" restriction is replaced by the new behaviour. While there, the "same write mask and blend mode" restriction now mentions `GraphicsDevice.supportsIndependentBlending` / `BlendState.setAttachment` (engine 2.22, playcanvas/engine#9140), which the page had not caught up with.
- Example blurb mentions the per-attachment clear colors the updated engine example uses.