### PR TITLE
Shader chunk migrations: scene environment uniforms (Engine v2.23)

### DIFF
--- a/docs/user-manual/graphics/shaders/migrations.md
+++ b/docs/user-manual/graphics/shaders/migrations.md
@@ -29,6 +29,65 @@ By doing this you will no longer see warning messages in the console.
 
 The following tables break down the chunk changes by Engine release.
 
+### *Engine v2.23*
+
+#### Scene environment textures use their own uniforms
+
+Until v2.23, the scene's environment atlas and skybox reached a material's shader under the same uniform names as the material's own environment textures, `texture_envAtlas` and `texture_cubeMap`: the engine copied the scene textures into the parameters of every `StandardMaterial` lit by the scene environment. As of v2.23 the renderer publishes the scene textures as `scene_envAtlas` and `scene_skybox`, and a material publishes only the textures it owns. The lit environment chunks declare and sample the texture through the `{LIT_ENV_ATLAS}` and `{LIT_ENV_CUBEMAP}` tokens, which the shader generator resolves to the scene or the material uniform for each shader variant. See [PR #9364](https://github.com/playcanvas/engine/pull/9364) for details.
+
+A custom override of one of these chunks that still hard-codes `texture_envAtlas` or `texture_cubeMap` keeps working on a material that has its own `envAtlas` or `cubeMap`, but receives no texture on a material lit by the scene environment: the sampler is never set, so the shader samples whatever texture happens to be bound to that unit.
+
+Environment resolution is also all-or-nothing from v2.23: a material with any environment texture of its own (`envAtlas`, `cubeMap` or `sphereMap`) uses only material textures for reflections, ambient and refraction, and a material with just a `cubeMap` or `sphereMap` takes its ambient from the constant `ambientLight`. Previously such a material took its ambient from the scene atlas.
+
+Affected chunks:
+
+- `src/scene/shader-lib/glsl/chunks/lit/frag/ambient.js`
+- `src/scene/shader-lib/glsl/chunks/lit/frag/reflectionEnv.js`
+- `src/scene/shader-lib/glsl/chunks/lit/frag/reflectionEnvHQ.js`
+- `src/scene/shader-lib/glsl/chunks/lit/frag/reflectionCube.js`
+- `src/scene/shader-lib/wgsl/chunks/lit/frag/ambient.js`
+- `src/scene/shader-lib/wgsl/chunks/lit/frag/reflectionEnv.js`
+- `src/scene/shader-lib/wgsl/chunks/lit/frag/reflectionEnvHQ.js`
+- `src/scene/shader-lib/wgsl/chunks/lit/frag/reflectionCube.js`
+
+**Migration:** In custom `ambientPS`, `reflectionEnvPS`, `reflectionEnvHQPS` and `reflectionCubePS` overrides, replace `texture_envAtlas` with `{LIT_ENV_ATLAS}` and `texture_cubeMap` with `{LIT_ENV_CUBEMAP}`, both in the declaration and at every sample. In WGSL the sampler follows the same pattern, `{LIT_ENV_ATLAS}Sampler`. Then set `material.shaderChunksVersion = '2.23'`.
+
+Before (GLSL):
+
+```glsl
+uniform sampler2D texture_envAtlas;
+
+vec3 linearA = {reflectionDecode}(texture2D(texture_envAtlas, uv0));
+```
+
+After (GLSL):
+
+```glsl
+uniform sampler2D {LIT_ENV_ATLAS};
+
+vec3 linearA = {reflectionDecode}(texture2D({LIT_ENV_ATLAS}, uv0));
+```
+
+Before (WGSL):
+
+```wgsl
+var texture_envAtlas: texture_2d<f32>;
+var texture_envAtlasSampler: sampler;
+
+let raw: vec4f = textureSample(texture_envAtlas, texture_envAtlasSampler, uv);
+```
+
+After (WGSL):
+
+```wgsl
+var {LIT_ENV_ATLAS}: texture_2d<f32>;
+var {LIT_ENV_ATLAS}Sampler: sampler;
+
+let raw: vec4f = textureSample({LIT_ENV_ATLAS}, {LIT_ENV_ATLAS}Sampler, uv);
+```
+
+---
+
 ### *Engine v2.20*
 
 #### MSDF text rendering reworked

--- a/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/shaders/migrations.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/user-manual/graphics/shaders/migrations.md
@@ -28,6 +28,65 @@ material.chunks.APIVersion = pc.CHUNKAPI_1_55;
 
 次の表は、Engine リリースごとのチャンクの変更点をまとめたものです。
 
+### *Engine v2.23*
+
+#### シーンの環境テクスチャが専用のユニフォームを使用するように
+
+v2.23 より前は、シーンの環境アトラスとスカイボックスは、マテリアル自身の環境テクスチャと同じユニフォーム名 `texture_envAtlas` および `texture_cubeMap` でマテリアルのシェーダーに渡されていました。エンジンは、シーン環境でライティングされるすべての `StandardMaterial` のパラメータにシーンのテクスチャをコピーしていました。v2.23 からは、レンダラーがシーンのテクスチャを `scene_envAtlas` および `scene_skybox` として公開し、マテリアルは自身が所有するテクスチャのみを公開します。ライティングの環境チャンクは、`{LIT_ENV_ATLAS}` および `{LIT_ENV_CUBEMAP}` トークンを通してテクスチャを宣言・サンプリングするようになり、シェーダージェネレーターがシェーダーバリアントごとにシーンまたはマテリアルのユニフォームへ解決します。詳細は [PR #9364](https://github.com/playcanvas/engine/pull/9364) を参照してください。
+
+これらのチャンクのカスタムオーバーライドが `texture_envAtlas` や `texture_cubeMap` をハードコードしたままの場合、独自の `envAtlas` または `cubeMap` を持つマテリアルでは引き続き動作しますが、シーン環境でライティングされるマテリアルではテクスチャを受け取れません。サンプラーが設定されないため、シェーダーはそのユニットにたまたまバインドされているテクスチャをサンプリングします。
+
+また、v2.23 から環境の解決は「オール・オア・ナッシング」になりました。マテリアルが独自の環境テクスチャ(`envAtlas`、`cubeMap`、`sphereMap`)を 1 つでも持つ場合、反射・アンビエント・屈折のすべてにマテリアルのテクスチャのみを使用し、`cubeMap` または `sphereMap` だけを持つマテリアルのアンビエントは定数の `ambientLight` から取得されます。以前は、そのようなマテリアルはシーンのアトラスからアンビエントを取得していました。
+
+影響を受けるチャンク:
+
+- `src/scene/shader-lib/glsl/chunks/lit/frag/ambient.js`
+- `src/scene/shader-lib/glsl/chunks/lit/frag/reflectionEnv.js`
+- `src/scene/shader-lib/glsl/chunks/lit/frag/reflectionEnvHQ.js`
+- `src/scene/shader-lib/glsl/chunks/lit/frag/reflectionCube.js`
+- `src/scene/shader-lib/wgsl/chunks/lit/frag/ambient.js`
+- `src/scene/shader-lib/wgsl/chunks/lit/frag/reflectionEnv.js`
+- `src/scene/shader-lib/wgsl/chunks/lit/frag/reflectionEnvHQ.js`
+- `src/scene/shader-lib/wgsl/chunks/lit/frag/reflectionCube.js`
+
+**移行方法:** カスタムの `ambientPS`、`reflectionEnvPS`、`reflectionEnvHQPS`、`reflectionCubePS` オーバーライドで、宣言とすべてのサンプリング箇所において `texture_envAtlas` を `{LIT_ENV_ATLAS}` に、`texture_cubeMap` を `{LIT_ENV_CUBEMAP}` に置き換えてください。WGSL ではサンプラーも同じパターン `{LIT_ENV_ATLAS}Sampler` に従います。その後、`material.shaderChunksVersion = '2.23'` を設定します。
+
+変更前 (GLSL):
+
+```glsl
+uniform sampler2D texture_envAtlas;
+
+vec3 linearA = {reflectionDecode}(texture2D(texture_envAtlas, uv0));
+```
+
+変更後 (GLSL):
+
+```glsl
+uniform sampler2D {LIT_ENV_ATLAS};
+
+vec3 linearA = {reflectionDecode}(texture2D({LIT_ENV_ATLAS}, uv0));
+```
+
+変更前 (WGSL):
+
+```wgsl
+var texture_envAtlas: texture_2d<f32>;
+var texture_envAtlasSampler: sampler;
+
+let raw: vec4f = textureSample(texture_envAtlas, texture_envAtlasSampler, uv);
+```
+
+変更後 (WGSL):
+
+```wgsl
+var {LIT_ENV_ATLAS}: texture_2d<f32>;
+var {LIT_ENV_ATLAS}Sampler: sampler;
+
+let raw: vec4f = textureSample({LIT_ENV_ATLAS}, {LIT_ENV_ATLAS}Sampler, uv);
+```
+
+---
+
 ### *Engine v2.20*
 
 #### MSDF テキストレンダリングの刷新


### PR DESCRIPTION
## Description

Documents the shader chunk changes of engine PR playcanvas/engine#9364 on the Shader Chunk Migrations page (English and Japanese):

- New **Engine v2.23** entry: the scene environment atlas and skybox are now published as `scene_envAtlas` / `scene_skybox`, and `ambientPS`, `reflectionEnvPS`, `reflectionEnvHQPS`, `reflectionCubePS` (GLSL and WGSL) sample through the `{LIT_ENV_ATLAS}` / `{LIT_ENV_CUBEMAP}` tokens.
- Explains what happens to a custom override that still hard-codes `texture_envAtlas` / `texture_cubeMap`, the all-or-nothing environment resolution change, the affected chunk list, the migration steps, and before/after snippets for GLSL and WGSL.

**Do not merge before the engine PR lands and Engine 2.23 is released.** The entry references behaviour that does not exist in 2.22.

## Checklist

- [x] `npm run lint` passes for the two pages
- [x] English and Japanese pages kept in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)
